### PR TITLE
docs: fixed external links in navbar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,12 +87,12 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/4subsea/fourinsight-xyz",
+            "url": "https://github.com/4Subsea/waveresponse-python",
             "icon": "fab fa-github",
         },
         {
             "name": "PyPI",
-            "url": "https://pypi.org/project/fourinsight-xyz",
+            "url": "https://pypi.org/project/waveresponse",
             "icon": "fas fa-box",
         },
     ],


### PR DESCRIPTION
Fixed links to github and pypi page in navbar icons