### PR TITLE
ENH: mirror an RAO about a symmetry plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Other
+docs/api_ref/*
+!docs/api_ref/index.rst
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/api_ref/index.rst
+++ b/docs/api_ref/index.rst
@@ -27,6 +27,7 @@ functions and methods.
     multiply
     polar_to_complex
     RAO
+    mirror
     rigid_transform
     rigid_transform_heave
     rigid_transform_surge

--- a/docs/user_guide/concepts_utils/rao.rst
+++ b/docs/user_guide/concepts_utils/rao.rst
@@ -95,14 +95,6 @@ the *n*\ th derivative of the original degree-of-freedom:
 Convert units
 -------------
 
-.. When you do rigid body transformation of RAOs, it is required that the rotational
-.. degree-of-freedom RAOs represents angles in *radians*. 
-
-.. Rigid body transformation of RAOs require that the rotational degree-of-freedom
-.. RAOs represent angles in *radians*. Then, it can be useful to be able to convert
-.. an RAO from e.g. :math:`deg/m` units to :math:`rad/m` units. This is done by a scaling
-.. of the RAO values with a factor :math:`\pi/180`.
-
 You can convert an :class:`~waveresponse.RAO` object between different units simply by scaling the RAO's
 values with an appropriate factor:
 
@@ -133,10 +125,6 @@ values with an appropriate factor:
 
 Mirror RAOs
 -------------
-
-.. Often, RAOs are provided from 0 to 180 degrees considering symmetry in x-z (surge-heave)
-.. plane. In these cases, it is usefull to mirror the RAO to obtain the full extended
-.. version defined in directional range [0, 360) degrees (or [0, 2 * numpy.pi) radians)
 
 You can mirror an :class:`~waveresponse.RAO` object defined in directional range [0, 180]
 degrees (or [0, :math:`\pi`] radians) to obtain the full extended version defined in range 

--- a/docs/user_guide/concepts_utils/rao.rst
+++ b/docs/user_guide/concepts_utils/rao.rst
@@ -127,3 +127,33 @@ values with an appropriate factor:
 
     .. math::
         H(\omega) \left[\frac{rad}{m}\right] = \frac{\pi}{180} \left[\frac{rad}{deg}\right] \cdot H(\omega) \left[\frac{deg}{m}\right]
+
+
+.. _mirror_raos:
+
+Mirror RAOs
+-------------
+
+.. Often, RAOs are provided from 0 to 180 degrees considering symmetry in x-z (surge-heave)
+.. plane. In these cases, it is usefull to mirror the RAO to obtain the full extended
+.. version defined in directional range [0, 360) degrees (or [0, 2 * numpy.pi) radians)
+
+You can mirror an :class:`~waveresponse.RAO` object defined in directional range [0, 180]
+degrees (or [0, :math:`\pi`] radians) to obtain the full extended version defined in range 
+[0, 360) degrees (or [0, :math:`2 \pi`) radians).
+
+The :meth:`~waveresponse.mirror` function takes the :class:`~waveresponse.RAO` object and
+the name of the degree-of-freedom as input arguments and returns the mirrored :class:`~waveresponse.RAO`
+object.
+
+.. code:: python
+
+    import waveresponse as wr
+
+    # mirror sway rao
+    full_rao = wr.mirror(rao, 'sway')
+
+.. tip::
+    :class:`~waveresponse.RAO` object must cover the directional range [0, 360) degrees
+    (or [0, 2 * numpy.pi) radians). This is required to calculate the response spectrum,
+    considering that wave spectrum is defined in the full range.

--- a/docs/user_guide/concepts_utils/rao.rst
+++ b/docs/user_guide/concepts_utils/rao.rst
@@ -123,25 +123,32 @@ values with an appropriate factor:
 
 .. _mirror_raos:
 
-Mirror RAOs
--------------
+Mirror an RAO about a symmetry plane
+------------------------------------
+If you have an :class:`~waveresponse.RAO` object defined only over half the directional
+domain (i.e., [0, 180) degrees), you may want to mirror this RAO about a symmetry plane
+to obtain an extended version of the RAO which is defined over the full directional domain
+(i.e., [0, 360) degrees). Symmetry mirroring is proveded by the :func:`~waveresponse.mirror`
+function; the function takes an :class:`~waveresponse.RAO` object and a degree-of-freedom
+as input, and outputs a new, extended :class:`~waveresponse.RAO` object.
 
-You can mirror an :class:`~waveresponse.RAO` object defined in directional range [0, 180]
-degrees (or [0, :math:`\pi`] radians) to obtain the full extended version defined in range 
-[0, 360) degrees (or [0, :math:`2 \pi`) radians).
 
-The :meth:`~waveresponse.mirror` function takes the :class:`~waveresponse.RAO` object and
-the name of the degree-of-freedom as input arguments and returns the mirrored :class:`~waveresponse.RAO`
-object.
+.. You can mirror an :class:`~waveresponse.RAO` object defined in directional range [0, 180]
+.. degrees (or [0, :math:`\pi`] radians) to obtain the full extended version defined in range 
+.. [0, 360) degrees (or [0, :math:`2 \pi`) radians).
+
+.. The :meth:`~waveresponse.mirror` function takes the :class:`~waveresponse.RAO` object and
+.. the name of the degree-of-freedom as input arguments and returns the mirrored :class:`~waveresponse.RAO`
+.. object.
 
 .. code:: python
 
     import waveresponse as wr
 
-    # mirror sway rao
-    full_rao = wr.mirror(rao, 'sway')
+    # Mirror sway rao
+    rao_full = wr.mirror(rao_half, 'sway')
 
-.. tip::
-    :class:`~waveresponse.RAO` object must cover the directional range [0, 360) degrees
-    (or [0, 2 * numpy.pi) radians). This is required to calculate the response spectrum,
-    considering that wave spectrum is defined in the full range.
+.. note::
+    When using an :class:`~waveresponse.RAO` object in response estimation, it is
+    important that the :class:`~waveresponse.RAO` is defined over the full directional
+    domain.

--- a/docs/user_guide/concepts_utils/rao.rst
+++ b/docs/user_guide/concepts_utils/rao.rst
@@ -132,15 +132,6 @@ to obtain an extended version of the RAO which is defined over the full directio
 function; the function takes an :class:`~waveresponse.RAO` object and a degree-of-freedom
 as input, and outputs a new, extended :class:`~waveresponse.RAO` object.
 
-
-.. You can mirror an :class:`~waveresponse.RAO` object defined in directional range [0, 180]
-.. degrees (or [0, :math:`\pi`] radians) to obtain the full extended version defined in range 
-.. [0, 360) degrees (or [0, :math:`2 \pi`) radians).
-
-.. The :meth:`~waveresponse.mirror` function takes the :class:`~waveresponse.RAO` object and
-.. the name of the degree-of-freedom as input arguments and returns the mirrored :class:`~waveresponse.RAO`
-.. object.
-
 .. code:: python
 
     import waveresponse as wr

--- a/docs/user_guide/concepts_utils/rao.rst
+++ b/docs/user_guide/concepts_utils/rao.rst
@@ -137,7 +137,7 @@ as input, and outputs a new, extended :class:`~waveresponse.RAO` object.
     import waveresponse as wr
 
     # Mirror sway rao
-    rao_full = wr.mirror(rao_half, 'sway')
+    rao_full = wr.mirror(rao, 'sway')
 
 .. note::
     When using an :class:`~waveresponse.RAO` object in response estimation, it is

--- a/src/waveresponse/__init__.py
+++ b/src/waveresponse/__init__.py
@@ -7,9 +7,9 @@ from ._core import (
     WaveSpectrum,
     calculate_response,
     complex_to_polar,
+    mirror,
     multiply,
     polar_to_complex,
-    mirror
 )
 from ._standardized1d import (
     JONSWAP,

--- a/src/waveresponse/__init__.py
+++ b/src/waveresponse/__init__.py
@@ -9,6 +9,7 @@ from ._core import (
     complex_to_polar,
     multiply,
     polar_to_complex,
+    mirror
 )
 from ._standardized1d import (
     JONSWAP,
@@ -39,6 +40,7 @@ __all__ = [
     "ModifiedPiersonMoskowitz",
     "OchiHubble",
     "multiply",
+    "mirro",
     "polar_to_complex",
     "RAO",
     "rigid_transform",

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -166,9 +166,10 @@ def _cast_to_grid(grid):
 
     return new
 
+
 def mirror(rao, dof):
     """
-    Mirror an RAO object with symmetry in x-z plane, defined in the directional range 
+    Mirror an RAO object with symmetry in x-z plane, defined in the directional range
     [0, 180] degrees (or [0, numpy.pi] radians).
 
     Parameters
@@ -191,7 +192,7 @@ def mirror(rao, dof):
     if rao._degrees:
         periodicity = 360.0
     else:
-        periodicity = 2*np.pi()
+        periodicity = 2 * np.pi()
 
     if dof.lower() not in dof_names:
         raise ValueError(f"dof must be Surge, Sway, Heave, Roll, Pitch or Yaw")
@@ -199,9 +200,9 @@ def mirror(rao, dof):
     if not (0.0 <= dirs.all() <= periodicity / 2.0):
         raise ValueError(f"RAO must be defined between 0 and 180 (2 pi) degrees (rad).")
 
-    for dir,val in zip(dirs,vals.T):
+    for dir, val in zip(dirs, vals.T):
         dir_sym = periodicity - dir
-        val = np.reshape(val.copy(),(-1,1))
+        val = np.reshape(val.copy(), (-1, 1))
 
         if dir_sym < 360.0 and dir_sym != dir:
             dirs = np.append(dirs, dir_sym)
@@ -214,14 +215,15 @@ def mirror(rao, dof):
     vals = vals[:, sorted_args]
 
     return RAO(
-            freq,
-            dirs,
-            vals,
-            degrees=rao._degrees,
-            freq_hz=rao._freq_hz,
-            clockwise=rao.wave_convention["clockwise"],
-            waves_coming_from=rao.wave_convention["waves_coming_from"]
-        )
+        freq,
+        dirs,
+        vals,
+        degrees=rao._degrees,
+        freq_hz=rao._freq_hz,
+        clockwise=rao.wave_convention["clockwise"],
+        waves_coming_from=rao.wave_convention["waves_coming_from"],
+    )
+
 
 class Grid:
     """

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -196,7 +196,7 @@ def mirror(rao, dof):
     if dof.lower() not in ("surge", "sway", "heave", "roll", "pitch", "yaw"):
         raise ValueError(f"dof must be Surge, Sway, Heave, Roll, Pitch or Yaw")
 
-    if (dirs < 0.0).any() or (dirs > periodicity / 2.0).any()
+    if (dirs < 0.0).any() or (dirs > periodicity / 2.0).any():
         raise ValueError(f"RAO must be defined between 0 and 180 (2 pi) degrees (rad).")
 
     if dof.lower() in ["sway", "roll", "yaw"]:

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -196,7 +196,7 @@ def mirror(rao, dof):
     if dof.lower() not in ("surge", "sway", "heave", "roll", "pitch", "yaw"):
         raise ValueError(f"dof must be Surge, Sway, Heave, Roll, Pitch or Yaw")
 
-    if not (0.0 <= dirs.all() <= periodicity / 2.0):
+    if (dirs < 0.0).any() or (dirs > periodicity / 2.0).any()
         raise ValueError(f"RAO must be defined between 0 and 180 (2 pi) degrees (rad).")
 
     if dof.lower() in ["sway", "roll", "yaw"]:

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -186,15 +186,14 @@ def mirror(rao, dof):
         Extended (mirrored) RAO.
     """
 
-    dof_names = ("surge", "sway", "heave", "roll", "pitch", "yaw")
-    freq, dirs, vals = rao.grid(degrees=True)
+    freq, dirs, vals = rao.grid()
 
     if rao._degrees:
         periodicity = 360.0
     else:
         periodicity = 2 * np.pi()
 
-    if dof.lower() not in dof_names:
+    if dof.lower() not in ("surge", "sway", "heave", "roll", "pitch", "yaw"):
         raise ValueError(f"dof must be Surge, Sway, Heave, Roll, Pitch or Yaw")
 
     if not (0.0 <= dirs.all() <= periodicity / 2.0):

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -191,7 +191,7 @@ def mirror(rao, dof):
     if rao._degrees:
         periodicity = 360.0
     else:
-        periodicity = 2 * np.pi()
+        periodicity = 2 * np.pi
 
     if dof.lower() not in ("surge", "sway", "heave", "roll", "pitch", "yaw"):
         raise ValueError(f"dof must be Surge, Sway, Heave, Roll, Pitch or Yaw")

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -169,20 +169,19 @@ def _cast_to_grid(grid):
 
 def mirror(rao, dof):
     """
-    Mirror an RAO object with symmetry in x-z plane, defined in the directional range
-    [0, 180] degrees (or [0, numpy.pi] radians).
+    Mirrors an RAO object with symmetry in x-z plane, defined in the directional range
+    [0, 180) degrees (or [0, numpy.pi) radians).
 
     Parameters
     ----------
-    rao : RAO object
-        RAO.
-    dof : str
-        Name of the degree of freedom. `surge`, `sway`, `heave`, `roll`, `pitch`, `yaw`
-        are accepted.
+    rao : RAO
+        RAO object.
+    dof : {`surge`, `sway`, `heave`, `roll`, `pitch`, `yaw`}
+        Which degree-of-freedaom the RAO object represents.
 
-    Return
-    ------
-    rao : RAO object
+    Returns
+    -------
+    rao : RAO
         Extended (mirrored) RAO.
     """
 
@@ -194,12 +193,16 @@ def mirror(rao, dof):
         periodicity = 2 * np.pi
 
     if dof.lower() not in ("surge", "sway", "heave", "roll", "pitch", "yaw"):
-        raise ValueError(f"dof must be Surge, Sway, Heave, Roll, Pitch or Yaw")
+        raise ValueError(
+            "`dof` must be 'surge', 'sway', 'heave', 'roll', 'pitch' or 'yaw'"
+        )
 
     if (dirs < 0.0).any() or (dirs > periodicity / 2.0).any():
-        raise ValueError(f"RAO must be defined between 0 and 180 (2 pi) degrees (rad).")
+        raise ValueError(
+            "`rao` must be defined between 0 and 180 degrees (or 0 and 2pi radians)."
+        )
 
-    if dof.lower() in ["sway", "roll", "yaw"]:
+    if dof.lower() in ("sway", "roll", "yaw"):
         scale_phase = -1
     else:
         scale_phase = 1

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -217,8 +217,7 @@ def mirror(rao, dof):
         vals_mirrored,
         degrees=rao._degrees,
         freq_hz=rao._freq_hz,
-        clockwise=rao.wave_convention["clockwise"],
-        waves_coming_from=rao.wave_convention["waves_coming_from"],
+        **rao.wave_convention,
     )
 
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -207,7 +207,7 @@ def mirror(rao, dof):
     mirror_mask = (dirs != 0) & (dirs != periodicity / 2)
 
     vals_mirrored = np.concatenate(
-        (vals, scale_phase * vals[:, mirror_mask][::-1]), axis=1
+        (vals, scale_phase * vals[:, mirror_mask][:, ::-1]), axis=1
     )
     dirs_mirrored = np.concatenate((dirs, periodicity - dirs[mirror_mask][::-1]))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -65,6 +65,7 @@ def rao(freq_dirs):
     )
     return rao
 
+
 @pytest.fixture
 def rao_for_mirroring():
 
@@ -79,6 +80,7 @@ def rao_for_mirroring():
     )
 
     return wr.RAO(freq, dirs, vals, degrees=True)
+
 
 @pytest.fixture
 def directional_spectrum(freq_dirs):
@@ -389,7 +391,6 @@ class Test_multiply:
 
 
 class Test_mirror:
-
     def test_sway(self, rao_for_mirroring):
         rao_out = mirror(rao_for_mirroring, "sway")
         freq_out, dirs_out, vals_out = rao_out.grid()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,6 +15,7 @@ from waveresponse import (
     calculate_response,
     complex_to_polar,
     polar_to_complex,
+    mirror,
 )
 from waveresponse._core import _check_is_similar, _robust_modulus
 
@@ -371,6 +372,157 @@ class Test_multiply:
 
         with pytest.raises(ValueError):
             wr.multiply(grid1, grid2)
+
+
+class Test_mirror:
+    freq = np.linspace(0, 1.0, 3)
+    dirs = np.linspace(0, 180, 3, endpoint=True)
+    vals = np.array(
+        [[ 5.+9.j,  1.-4.j,  3.-2.j],
+        [ 7.-9.j,  2.+2.j, 10.+9.j],
+        [ 6.+1.j,  1.-4.j,  7.+3.j]]
+    )
+
+    rao_in = wr.RAO(
+        freq,
+        dirs,
+        vals,
+        degrees=True
+    )
+
+    def test_sway(self):
+        rao_out = mirror(self.rao_in,'sway')
+        freq_out, dirs_out, vals_out = rao_out.grid()
+
+        freq_expect = self.freq
+        dirs_expect = np.linspace(0, 360, 4, endpoint=False)
+        vals_expect = np.array(
+            [[ 5.+9.j, 1.-4.j, 3.-2.j, -1.+4.j],
+             [ 7.-9.j, 2.+2.j, 10.+9.j, -2.-2.j],
+             [ 6.+1.j, 1.-4.j, 7.+3.j, -1.+4.j]]
+        )
+
+        assert isinstance(rao_out, RAO)
+        assert rao_out._freq_hz == self.rao_in._freq_hz
+        assert rao_out._clockwise == self.rao_in._clockwise
+        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
+        assert rao_out._degrees == self.rao_in._degrees
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_surge(self):
+        rao_out = mirror(self.rao_in,'surge')
+        freq_out, dirs_out, vals_out = rao_out.grid()
+
+        freq_expect = self.freq
+        dirs_expect = np.linspace(0, 360, 4, endpoint=False)
+        vals_expect = np.array(
+            [[ 5.+9.j, 1.-4.j, 3.-2.j, 1.-4.j],
+             [ 7.-9.j, 2.+2.j, 10.+9.j, 2.+2.j],
+             [ 6.+1.j, 1.-4.j, 7.+3.j, 1.-4.j]]
+        )
+
+        assert isinstance(rao_out, RAO)
+        assert rao_out._freq_hz == self.rao_in._freq_hz
+        assert rao_out._clockwise == self.rao_in._clockwise
+        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
+        assert rao_out._degrees == self.rao_in._degrees
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_heave(self):
+        rao_out = mirror(self.rao_in,'heave')
+        freq_out, dirs_out, vals_out = rao_out.grid()
+
+        freq_expect = self.freq
+        dirs_expect = np.linspace(0, 360, 4, endpoint=False)
+        vals_expect = np.array(
+            [[ 5.+9.j, 1.-4.j, 3.-2.j, 1.-4.j],
+             [ 7.-9.j, 2.+2.j, 10.+9.j, 2.+2.j],
+             [ 6.+1.j, 1.-4.j, 7.+3.j, 1.-4.j]]
+        )
+
+        assert isinstance(rao_out, RAO)
+        assert rao_out._freq_hz == self.rao_in._freq_hz
+        assert rao_out._clockwise == self.rao_in._clockwise
+        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
+        assert rao_out._degrees == self.rao_in._degrees
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_pitch(self):
+        rao_out = mirror(self.rao_in,'pitch')
+        freq_out, dirs_out, vals_out = rao_out.grid()
+
+        freq_expect = self.freq
+        dirs_expect = np.linspace(0, 360, 4, endpoint=False)
+        vals_expect = np.array(
+            [[ 5.+9.j, 1.-4.j, 3.-2.j, 1.-4.j],
+             [ 7.-9.j, 2.+2.j, 10.+9.j, 2.+2.j],
+             [ 6.+1.j, 1.-4.j, 7.+3.j, 1.-4.j]]
+        )
+
+        assert isinstance(rao_out, RAO)
+        assert rao_out._freq_hz == self.rao_in._freq_hz
+        assert rao_out._clockwise == self.rao_in._clockwise
+        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
+        assert rao_out._degrees == self.rao_in._degrees
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_roll(self):
+        rao_out = mirror(self.rao_in,'roll')
+        freq_out, dirs_out, vals_out = rao_out.grid()
+
+        freq_expect = self.freq
+        dirs_expect = np.linspace(0, 360, 4, endpoint=False)
+        vals_expect = np.array(
+            [[ 5.+9.j, 1.-4.j, 3.-2.j, -1.+4.j],
+             [ 7.-9.j, 2.+2.j, 10.+9.j, -2.-2.j],
+             [ 6.+1.j, 1.-4.j, 7.+3.j, -1.+4.j]]
+        )
+
+        assert isinstance(rao_out, RAO)
+        assert rao_out._freq_hz == self.rao_in._freq_hz
+        assert rao_out._clockwise == self.rao_in._clockwise
+        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
+        assert rao_out._degrees == self.rao_in._degrees
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_yaw(self):
+        rao_out = mirror(self.rao_in,'yaw')
+        freq_out, dirs_out, vals_out = rao_out.grid()
+
+        freq_expect = self.freq
+        dirs_expect = np.linspace(0, 360, 4, endpoint=False)
+        vals_expect = np.array(
+            [[ 5.+9.j, 1.-4.j, 3.-2.j, -1.+4.j],
+             [ 7.-9.j, 2.+2.j, 10.+9.j, -2.-2.j],
+             [ 6.+1.j, 1.-4.j, 7.+3.j, -1.+4.j]]
+        )
+
+        assert isinstance(rao_out, RAO)
+        assert rao_out._freq_hz == self.rao_in._freq_hz
+        assert rao_out._clockwise == self.rao_in._clockwise
+        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
+        assert rao_out._degrees == self.rao_in._degrees
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_raises_dirs(self,rao):
+        with pytest.raises(ValueError):
+            mirror(rao, 'sway')
+
+    def test_raises_dof(self):
+        with pytest.raises(ValueError):
+            mirror(self.rao_in, 'spin')
 
 
 class Test_Grid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,6 +81,7 @@ def rao_for_mirroring_deg():
 
     return wr.RAO(freq, dirs, vals, degrees=True)
 
+
 @pytest.fixture
 def rao_for_mirroring_rad():
 
@@ -95,6 +96,7 @@ def rao_for_mirroring_rad():
     )
 
     return wr.RAO(freq, dirs, vals, degrees=False)
+
 
 @pytest.fixture
 def directional_spectrum(freq_dirs):
@@ -548,7 +550,7 @@ class Test_mirror:
         freq_out, dirs_out, vals_out = rao_out.grid()
 
         freq_expect = rao_for_mirroring_rad.freq()
-        dirs_expect = np.linspace(0, 2*np.pi, 4, endpoint=False)
+        dirs_expect = np.linspace(0, 2 * np.pi, 4, endpoint=False)
         vals_expect = np.array(
             [
                 [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, -1.0 + 4.0j],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,8 +14,8 @@ from waveresponse import (
     WaveSpectrum,
     calculate_response,
     complex_to_polar,
-    polar_to_complex,
     mirror,
+    polar_to_complex,
 )
 from waveresponse._core import _check_is_similar, _robust_modulus
 
@@ -378,28 +378,27 @@ class Test_mirror:
     freq = np.linspace(0, 1.0, 3)
     dirs = np.linspace(0, 180, 3, endpoint=True)
     vals = np.array(
-        [[ 5.+9.j,  1.-4.j,  3.-2.j],
-        [ 7.-9.j,  2.+2.j, 10.+9.j],
-        [ 6.+1.j,  1.-4.j,  7.+3.j]]
+        [
+            [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j],
+            [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j],
+            [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j],
+        ]
     )
 
-    rao_in = wr.RAO(
-        freq,
-        dirs,
-        vals,
-        degrees=True
-    )
+    rao_in = wr.RAO(freq, dirs, vals, degrees=True)
 
     def test_sway(self):
-        rao_out = mirror(self.rao_in,'sway')
+        rao_out = mirror(self.rao_in, "sway")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
         freq_expect = self.freq
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
-            [[ 5.+9.j, 1.-4.j, 3.-2.j, -1.+4.j],
-             [ 7.-9.j, 2.+2.j, 10.+9.j, -2.-2.j],
-             [ 6.+1.j, 1.-4.j, 7.+3.j, -1.+4.j]]
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, -1.0 + 4.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j, -2.0 - 2.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j, -1.0 + 4.0j],
+            ]
         )
 
         assert isinstance(rao_out, RAO)
@@ -412,15 +411,17 @@ class Test_mirror:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_surge(self):
-        rao_out = mirror(self.rao_in,'surge')
+        rao_out = mirror(self.rao_in, "surge")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
         freq_expect = self.freq
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
-            [[ 5.+9.j, 1.-4.j, 3.-2.j, 1.-4.j],
-             [ 7.-9.j, 2.+2.j, 10.+9.j, 2.+2.j],
-             [ 6.+1.j, 1.-4.j, 7.+3.j, 1.-4.j]]
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, 1.0 - 4.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j, 2.0 + 2.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j, 1.0 - 4.0j],
+            ]
         )
 
         assert isinstance(rao_out, RAO)
@@ -433,15 +434,17 @@ class Test_mirror:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_heave(self):
-        rao_out = mirror(self.rao_in,'heave')
+        rao_out = mirror(self.rao_in, "heave")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
         freq_expect = self.freq
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
-            [[ 5.+9.j, 1.-4.j, 3.-2.j, 1.-4.j],
-             [ 7.-9.j, 2.+2.j, 10.+9.j, 2.+2.j],
-             [ 6.+1.j, 1.-4.j, 7.+3.j, 1.-4.j]]
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, 1.0 - 4.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j, 2.0 + 2.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j, 1.0 - 4.0j],
+            ]
         )
 
         assert isinstance(rao_out, RAO)
@@ -454,15 +457,17 @@ class Test_mirror:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_pitch(self):
-        rao_out = mirror(self.rao_in,'pitch')
+        rao_out = mirror(self.rao_in, "pitch")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
         freq_expect = self.freq
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
-            [[ 5.+9.j, 1.-4.j, 3.-2.j, 1.-4.j],
-             [ 7.-9.j, 2.+2.j, 10.+9.j, 2.+2.j],
-             [ 6.+1.j, 1.-4.j, 7.+3.j, 1.-4.j]]
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, 1.0 - 4.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j, 2.0 + 2.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j, 1.0 - 4.0j],
+            ]
         )
 
         assert isinstance(rao_out, RAO)
@@ -475,15 +480,17 @@ class Test_mirror:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_roll(self):
-        rao_out = mirror(self.rao_in,'roll')
+        rao_out = mirror(self.rao_in, "roll")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
         freq_expect = self.freq
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
-            [[ 5.+9.j, 1.-4.j, 3.-2.j, -1.+4.j],
-             [ 7.-9.j, 2.+2.j, 10.+9.j, -2.-2.j],
-             [ 6.+1.j, 1.-4.j, 7.+3.j, -1.+4.j]]
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, -1.0 + 4.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j, -2.0 - 2.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j, -1.0 + 4.0j],
+            ]
         )
 
         assert isinstance(rao_out, RAO)
@@ -496,15 +503,17 @@ class Test_mirror:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_yaw(self):
-        rao_out = mirror(self.rao_in,'yaw')
+        rao_out = mirror(self.rao_in, "yaw")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
         freq_expect = self.freq
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
-            [[ 5.+9.j, 1.-4.j, 3.-2.j, -1.+4.j],
-             [ 7.-9.j, 2.+2.j, 10.+9.j, -2.-2.j],
-             [ 6.+1.j, 1.-4.j, 7.+3.j, -1.+4.j]]
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, -1.0 + 4.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j, -2.0 - 2.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j, -1.0 + 4.0j],
+            ]
         )
 
         assert isinstance(rao_out, RAO)
@@ -516,13 +525,13 @@ class Test_mirror:
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_raises_dirs(self,rao):
+    def test_raises_dirs(self, rao):
         with pytest.raises(ValueError):
-            mirror(rao, 'sway')
+            mirror(rao, "sway")
 
     def test_raises_dof(self):
         with pytest.raises(ValueError):
-            mirror(self.rao_in, 'spin')
+            mirror(self.rao_in, "spin")
 
 
 class Test_Grid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -67,7 +67,7 @@ def rao(freq_dirs):
 
 
 @pytest.fixture
-def rao_for_mirroring():
+def rao_for_mirroring_deg():
 
     freq = np.linspace(0, 1.0, 3)
     dirs = np.linspace(0, 180, 3, endpoint=True)
@@ -81,6 +81,20 @@ def rao_for_mirroring():
 
     return wr.RAO(freq, dirs, vals, degrees=True)
 
+@pytest.fixture
+def rao_for_mirroring_rad():
+
+    freq = np.linspace(0, 1.0, 3)
+    dirs = np.linspace(0, np.pi, 3, endpoint=True)
+    vals = np.array(
+        [
+            [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j],
+            [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j],
+            [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j],
+        ]
+    )
+
+    return wr.RAO(freq, dirs, vals, degrees=False)
 
 @pytest.fixture
 def directional_spectrum(freq_dirs):
@@ -391,11 +405,11 @@ class Test_multiply:
 
 
 class Test_mirror:
-    def test_sway(self, rao_for_mirroring):
-        rao_out = mirror(rao_for_mirroring, "sway")
+    def test_sway(self, rao_for_mirroring_deg):
+        rao_out = mirror(rao_for_mirroring_deg, "sway")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring.freq()
+        freq_expect = rao_for_mirroring_deg.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -406,19 +420,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring._degrees
+        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring_deg._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_surge(self, rao_for_mirroring):
-        rao_out = mirror(rao_for_mirroring, "surge")
+    def test_surge(self, rao_for_mirroring_deg):
+        rao_out = mirror(rao_for_mirroring_deg, "surge")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring.freq()
+        freq_expect = rao_for_mirroring_deg.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -429,19 +443,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring._degrees
+        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring_deg._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_heave(self, rao_for_mirroring):
-        rao_out = mirror(rao_for_mirroring, "heave")
+    def test_heave(self, rao_for_mirroring_deg):
+        rao_out = mirror(rao_for_mirroring_deg, "heave")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring.freq()
+        freq_expect = rao_for_mirroring_deg.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -452,19 +466,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring._degrees
+        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring_deg._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_pitch(self, rao_for_mirroring):
-        rao_out = mirror(rao_for_mirroring, "pitch")
+    def test_pitch(self, rao_for_mirroring_deg):
+        rao_out = mirror(rao_for_mirroring_deg, "pitch")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring.freq()
+        freq_expect = rao_for_mirroring_deg.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -475,19 +489,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring._degrees
+        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring_deg._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_roll(self, rao_for_mirroring):
-        rao_out = mirror(rao_for_mirroring, "roll")
+    def test_roll(self, rao_for_mirroring_deg):
+        rao_out = mirror(rao_for_mirroring_deg, "roll")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring.freq()
+        freq_expect = rao_for_mirroring_deg.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -498,19 +512,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring._degrees
+        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring_deg._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_yaw(self, rao_for_mirroring):
-        rao_out = mirror(rao_for_mirroring, "yaw")
+    def test_yaw(self, rao_for_mirroring_deg):
+        rao_out = mirror(rao_for_mirroring_deg, "yaw")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring.freq()
+        freq_expect = rao_for_mirroring_deg.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -521,10 +535,33 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring._degrees
+        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring_deg._degrees
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_yaw_rad(self, rao_for_mirroring_rad):
+        rao_out = mirror(rao_for_mirroring_rad, "yaw")
+        freq_out, dirs_out, vals_out = rao_out.grid()
+
+        freq_expect = rao_for_mirroring_rad.freq()
+        dirs_expect = np.linspace(0, 2*np.pi, 4, endpoint=False)
+        vals_expect = np.array(
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j, -1.0 + 4.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j, -2.0 - 2.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j, -1.0 + 4.0j],
+            ]
+        )
+
+        assert isinstance(rao_out, RAO)
+        assert rao_out._freq_hz == rao_for_mirroring_rad._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring_rad._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring_rad._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring_rad._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
@@ -533,9 +570,9 @@ class Test_mirror:
         with pytest.raises(ValueError):
             mirror(rao, "sway")
 
-    def test_raises_dof(self, rao_for_mirroring):
+    def test_raises_dof(self, rao_for_mirroring_deg):
         with pytest.raises(ValueError):
-            mirror(rao_for_mirroring, "invalid-dof")
+            mirror(rao_for_mirroring_deg, "invalid-dof")
 
 
 class Test_Grid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -67,7 +67,7 @@ def rao(freq_dirs):
 
 
 @pytest.fixture
-def rao_for_mirroring_deg():
+def rao_for_mirroring():
 
     freq = np.linspace(0, 1.0, 3)
     dirs = np.linspace(0, 180, 3, endpoint=True)
@@ -80,22 +80,6 @@ def rao_for_mirroring_deg():
     )
 
     return wr.RAO(freq, dirs, vals, degrees=True)
-
-
-@pytest.fixture
-def rao_for_mirroring_rad():
-
-    freq = np.linspace(0, 1.0, 3)
-    dirs = np.linspace(0, np.pi, 3, endpoint=True)
-    vals = np.array(
-        [
-            [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j],
-            [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j],
-            [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j],
-        ]
-    )
-
-    return wr.RAO(freq, dirs, vals, degrees=False)
 
 
 @pytest.fixture
@@ -407,11 +391,11 @@ class Test_multiply:
 
 
 class Test_mirror:
-    def test_sway(self, rao_for_mirroring_deg):
-        rao_out = mirror(rao_for_mirroring_deg, "sway")
+    def test_sway(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "sway")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring_deg.freq()
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -422,19 +406,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring_deg._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_surge(self, rao_for_mirroring_deg):
-        rao_out = mirror(rao_for_mirroring_deg, "surge")
+    def test_surge(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "surge")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring_deg.freq()
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -445,19 +429,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring_deg._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_heave(self, rao_for_mirroring_deg):
-        rao_out = mirror(rao_for_mirroring_deg, "heave")
+    def test_heave(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "heave")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring_deg.freq()
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -468,19 +452,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring_deg._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_pitch(self, rao_for_mirroring_deg):
-        rao_out = mirror(rao_for_mirroring_deg, "pitch")
+    def test_pitch(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "pitch")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring_deg.freq()
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -491,19 +475,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring_deg._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_roll(self, rao_for_mirroring_deg):
-        rao_out = mirror(rao_for_mirroring_deg, "roll")
+    def test_roll(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "roll")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring_deg.freq()
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -514,19 +498,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring_deg._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_yaw(self, rao_for_mirroring_deg):
-        rao_out = mirror(rao_for_mirroring_deg, "yaw")
+    def test_yaw(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "yaw")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = rao_for_mirroring_deg.freq()
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -537,15 +521,27 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == rao_for_mirroring_deg._freq_hz
-        assert rao_out._clockwise == rao_for_mirroring_deg._clockwise
-        assert rao_out._waves_coming_from == rao_for_mirroring_deg._waves_coming_from
-        assert rao_out._degrees == rao_for_mirroring_deg._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_yaw_rad(self, rao_for_mirroring_rad):
+    def test_yaw_rad(self):
+        freq = np.linspace(0, 1.0, 3)
+        dirs = np.linspace(0, np.pi, 3, endpoint=True)
+        vals = np.array(
+            [
+                [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j],
+                [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j],
+                [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j],
+            ]
+        )
+
+        rao_for_mirroring_rad = wr.RAO(freq, dirs, vals, degrees=False)
+
         rao_out = mirror(rao_for_mirroring_rad, "yaw")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
@@ -572,9 +568,9 @@ class Test_mirror:
         with pytest.raises(ValueError):
             mirror(rao, "sway")
 
-    def test_raises_dof(self, rao_for_mirroring_deg):
+    def test_raises_dof(self, rao_for_mirroring):
         with pytest.raises(ValueError):
-            mirror(rao_for_mirroring_deg, "invalid-dof")
+            mirror(rao_for_mirroring, "invalid-dof")
 
 
 class Test_Grid:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -565,6 +565,7 @@ class Test_mirror:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_raises_dirs(self, rao):
+        # Try to mirror an RAO with directions greater than 180 degrees
         with pytest.raises(ValueError):
             mirror(rao, "sway")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -65,6 +65,20 @@ def rao(freq_dirs):
     )
     return rao
 
+@pytest.fixture
+def rao_for_mirroring():
+
+    freq = np.linspace(0, 1.0, 3)
+    dirs = np.linspace(0, 180, 3, endpoint=True)
+    vals = np.array(
+        [
+            [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j],
+            [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j],
+            [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j],
+        ]
+    )
+
+    return wr.RAO(freq, dirs, vals, degrees=True)
 
 @pytest.fixture
 def directional_spectrum(freq_dirs):
@@ -375,23 +389,12 @@ class Test_multiply:
 
 
 class Test_mirror:
-    freq = np.linspace(0, 1.0, 3)
-    dirs = np.linspace(0, 180, 3, endpoint=True)
-    vals = np.array(
-        [
-            [5.0 + 9.0j, 1.0 - 4.0j, 3.0 - 2.0j],
-            [7.0 - 9.0j, 2.0 + 2.0j, 10.0 + 9.0j],
-            [6.0 + 1.0j, 1.0 - 4.0j, 7.0 + 3.0j],
-        ]
-    )
 
-    rao_in = wr.RAO(freq, dirs, vals, degrees=True)
-
-    def test_sway(self):
-        rao_out = mirror(self.rao_in, "sway")
+    def test_sway(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "sway")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = self.freq
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -402,19 +405,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == self.rao_in._freq_hz
-        assert rao_out._clockwise == self.rao_in._clockwise
-        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
-        assert rao_out._degrees == self.rao_in._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_surge(self):
-        rao_out = mirror(self.rao_in, "surge")
+    def test_surge(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "surge")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = self.freq
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -425,19 +428,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == self.rao_in._freq_hz
-        assert rao_out._clockwise == self.rao_in._clockwise
-        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
-        assert rao_out._degrees == self.rao_in._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_heave(self):
-        rao_out = mirror(self.rao_in, "heave")
+    def test_heave(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "heave")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = self.freq
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -448,19 +451,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == self.rao_in._freq_hz
-        assert rao_out._clockwise == self.rao_in._clockwise
-        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
-        assert rao_out._degrees == self.rao_in._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_pitch(self):
-        rao_out = mirror(self.rao_in, "pitch")
+    def test_pitch(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "pitch")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = self.freq
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -471,19 +474,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == self.rao_in._freq_hz
-        assert rao_out._clockwise == self.rao_in._clockwise
-        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
-        assert rao_out._degrees == self.rao_in._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_roll(self):
-        rao_out = mirror(self.rao_in, "roll")
+    def test_roll(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "roll")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = self.freq
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -494,19 +497,19 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == self.rao_in._freq_hz
-        assert rao_out._clockwise == self.rao_in._clockwise
-        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
-        assert rao_out._degrees == self.rao_in._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_yaw(self):
-        rao_out = mirror(self.rao_in, "yaw")
+    def test_yaw(self, rao_for_mirroring):
+        rao_out = mirror(rao_for_mirroring, "yaw")
         freq_out, dirs_out, vals_out = rao_out.grid()
 
-        freq_expect = self.freq
+        freq_expect = rao_for_mirroring.freq()
         dirs_expect = np.linspace(0, 360, 4, endpoint=False)
         vals_expect = np.array(
             [
@@ -517,10 +520,10 @@ class Test_mirror:
         )
 
         assert isinstance(rao_out, RAO)
-        assert rao_out._freq_hz == self.rao_in._freq_hz
-        assert rao_out._clockwise == self.rao_in._clockwise
-        assert rao_out._waves_coming_from == self.rao_in._waves_coming_from
-        assert rao_out._degrees == self.rao_in._degrees
+        assert rao_out._freq_hz == rao_for_mirroring._freq_hz
+        assert rao_out._clockwise == rao_for_mirroring._clockwise
+        assert rao_out._waves_coming_from == rao_for_mirroring._waves_coming_from
+        assert rao_out._degrees == rao_for_mirroring._degrees
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
@@ -529,9 +532,9 @@ class Test_mirror:
         with pytest.raises(ValueError):
             mirror(rao, "sway")
 
-    def test_raises_dof(self):
+    def test_raises_dof(self, rao_for_mirroring):
         with pytest.raises(ValueError):
-            mirror(self.rao_in, "spin")
+            mirror(rao_for_mirroring, "invalid-dof")
 
 
 class Test_Grid:


### PR DESCRIPTION
### This PR is related to user story DST-336 As 4S engineer I want to mirror the symmetric RAOs when creating RAO object using waveresponse

## Description
Often, RAOs are provided from 0 to 180 degrees considering symmetry in x-z (surge-heave) plane. In these cases, it is usefull to mirror the RAO to obtain the full extended version defined in directional range [0, 360) degrees (or [0, 2 * numpy.pi) radians)

This PR adds a mirror function in _core.py outside RAO class to mirror and RAO object defined in the range [0, 180] degrees (or [0, $\pi$] radians) to obtain the full extended version defined in range [0, 360) degrees (or [0, $2 \pi$) radians).

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
