### PR TITLE
Dst 343  bug directions

### DIFF
--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1241,10 +1241,12 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
     @staticmethod
     def _full_range_dir(x):
         """Add direction range bounds (0.0 and 2.0 * np.pi)"""
+        range_end = np.nextafter(2.0 * np.pi, 0., dtype=type(x[0]))
+
         if x[0] != 0.0:
             x = np.r_[0.0, x]
-        if x[-1] < (2.0 * np.pi - 1e-8):
-            x = np.r_[x, 2.0 * np.pi - 1e-8]
+        if x[-1] < range_end:
+            x = np.r_[x, range_end]
         return x
 
     def var(self):

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -260,8 +260,8 @@ class Grid:
         clockwise=False,
         waves_coming_from=True,
     ):
-        self._freq = np.asarray_chkfinite(freq, dtype="float64").copy()
-        self._dirs = np.asarray_chkfinite(dirs, dtype="float64").copy()
+        self._freq = np.asarray_chkfinite(freq).copy()
+        self._dirs = np.asarray_chkfinite(dirs).copy()
         self._vals = np.asarray_chkfinite(vals).copy()
         self._clockwise = clockwise
         self._waves_coming_from = waves_coming_from

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -260,8 +260,8 @@ class Grid:
         clockwise=False,
         waves_coming_from=True,
     ):
-        self._freq = np.asarray_chkfinite(freq).copy()
-        self._dirs = np.asarray_chkfinite(dirs).copy()
+        self._freq = np.asarray_chkfinite(freq, dtype="float64").copy()
+        self._dirs = np.asarray_chkfinite(dirs, dtype="float64").copy()
         self._vals = np.asarray_chkfinite(vals).copy()
         self._clockwise = clockwise
         self._waves_coming_from = waves_coming_from

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2866,6 +2866,12 @@ class Test_DirectionalSpectrum:
         out = DirectionalSpectrum._full_range_dir(x)
         np.testing.assert_array_almost_equal(out, expect)
 
+    @pytest.mark.parametrize("x,expect", testdata_full_range_dir)
+    def test_full_range_dir_float32(self, x, expect):
+        x = np.asarray(x, dtype="float32")
+        out = DirectionalSpectrum._full_range_dir(x)
+        np.testing.assert_array_almost_equal(out, expect)
+
     def test_var(self):
         y0 = 0.0
         y1 = 2


### PR DESCRIPTION
### This PR is related to user story DST-343

## Description
_full_range_dir() function introduces an error for directions given in float32 dtype

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
