### PR TITLE
Set default JONSWAP peak enhancement factor to 3.3

### DIFF
--- a/docs/user_guide/standardized_spectra.rst
+++ b/docs/user_guide/standardized_spectra.rst
@@ -94,7 +94,7 @@ JONSWAP spectrum given three parameters (i.e., :math:`H_s`, :math:`T_p` and :mat
 
     hs = 3.5
     tp = 10.0
-    freq, vals = spectrum(hs, tp, gamma=2)
+    freq, vals = spectrum(hs, tp, gamma=3.3)
 
 .. note::
 

--- a/src/waveresponse/_standardized1d.py
+++ b/src/waveresponse/_standardized1d.py
@@ -244,7 +244,7 @@ class JONSWAP(ModifiedPiersonMoskowitz):
     OchiHubble : Ochi-Hubble (three-parameter) wave spectrum.
     """
 
-    def __call__(self, hs, tp, gamma=1, freq_hz=None):
+    def __call__(self, hs, tp, gamma=3.3, freq_hz=None):
         """
         Generate wave spectrum.
 
@@ -255,7 +255,7 @@ class JONSWAP(ModifiedPiersonMoskowitz):
         tp : float
             Peak period, Tp.
         gamma : float
-            Peak enhancement factor.
+            Peak enhancement factor. Default value is 3.3.
         freq_hz : bool, optional
             Whether to return the frequencies and spectrum in terms of Hz (`True`)
             or rad/s (`False`). If `None` (default), the original units of `freq` is


### PR DESCRIPTION
### This PR is related to user story DST-

## Description
Set the default peak enhancement factor to 3.3 (which seams to be the average value in literature).

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
