### PR TITLE
Add functionality for computing extreme values to DirectionalSpectrum class

### DIFF
--- a/docs/user_guide/concepts_utils/directional_spectrum.rst
+++ b/docs/user_guide/concepts_utils/directional_spectrum.rst
@@ -83,6 +83,7 @@ Calculate extreme values:
 
 .. code-block:: python
 
-    # Calculate extreme values for e.g. a 3-hour realization of the spectrum
-    mpm = spectrum.extreme(3 * 3600, q=0.37)   # most probable maximum (MPM)
-    q90 = spectrum.extreme(3 * 3600, q=0.90)   # 90-th quantile
+    duration = 3 * 3600   # 3 hours
+
+    mpm = spectrum.extreme(duration, q=0.37)   # most probable maximum (MPM)
+    q90 = spectrum.extreme(duration, q=0.90)   # 90-th quantile

--- a/docs/user_guide/concepts_utils/directional_spectrum.rst
+++ b/docs/user_guide/concepts_utils/directional_spectrum.rst
@@ -79,11 +79,13 @@ Calculate the mean zero-crossing period, Tz:
 
     wave.tz
 
-Calculate extreme values:
+Calculate extreme values using the :meth:`~waveresponse.DirectionalSpectrum.extreme`
+method. The method takes two arguments: the duration of the spectrum realization
+in seconds, and a quantile.
 
 .. code-block:: python
 
     duration = 3 * 3600   # 3 hours
 
     mpm = spectrum.extreme(duration, q=0.37)   # most probable maximum (MPM)
-    q90 = spectrum.extreme(duration, q=0.90)   # 90-th quantile
+    q90 = spectrum.extreme(duration, q=[0.5, 0.90, 0.99])   # 90-th quantile

--- a/docs/user_guide/concepts_utils/directional_spectrum.rst
+++ b/docs/user_guide/concepts_utils/directional_spectrum.rst
@@ -80,12 +80,12 @@ Calculate the mean zero-crossing period, Tz:
     wave.tz
 
 Calculate extreme values using the :meth:`~waveresponse.DirectionalSpectrum.extreme`
-method. The method takes two arguments: the duration of the spectrum realization
-in seconds, and a quantile.
+method. The method takes two arguments: the duration of the process (in seconds),
+and a quantile, ``q``.
 
 .. code-block:: python
 
     duration = 3 * 3600   # 3 hours
 
     mpm = spectrum.extreme(duration, q=0.37)   # most probable maximum (MPM)
-    q90 = spectrum.extreme(duration, q=[0.5, 0.90, 0.99])   # 90-th quantile
+    q90 = spectrum.extreme(duration, q=0.99)   # 90-th quantile

--- a/docs/user_guide/concepts_utils/directional_spectrum.rst
+++ b/docs/user_guide/concepts_utils/directional_spectrum.rst
@@ -78,3 +78,11 @@ Calculate the mean zero-crossing period, Tz:
 .. code-block:: python
 
     wave.tz
+
+Calculate extreme values:
+
+.. code-block:: python
+
+    # Calculate extreme values for e.g. a 3-hour realization of the spectrum
+    mpm = spectrum.extreme(3 * 3600, q=0.37)   # most probable maximum (MPM)
+    q90 = spectrum.extreme(3 * 3600, q=0.90)   # 90-th quantile

--- a/docs/user_guide/concepts_utils/directional_spectrum.rst
+++ b/docs/user_guide/concepts_utils/directional_spectrum.rst
@@ -72,3 +72,9 @@ method with the desired order, `n`.
     m2 = spectrum.moment(2)
 
     # Etc.
+
+Calculate the mean zero-crossing period, Tz:
+
+.. code-block:: python
+
+    wave.tz

--- a/docs/user_guide/concepts_utils/directional_spectrum.rst
+++ b/docs/user_guide/concepts_utils/directional_spectrum.rst
@@ -77,7 +77,7 @@ Calculate the mean zero-crossing period, Tz:
 
 .. code-block:: python
 
-    wave.tz
+    spectrum.tz
 
 Calculate extreme values using the :meth:`~waveresponse.DirectionalSpectrum.extreme`
 method. The method takes two arguments: the duration of the process (in seconds),

--- a/docs/user_guide/concepts_utils/wave_spectrum.rst
+++ b/docs/user_guide/concepts_utils/wave_spectrum.rst
@@ -80,12 +80,6 @@ Calculate the wave peak period, Tp:
 
     wave.tp
 
-Calculate the mean crossing period, Tz:
-
-.. code-block:: python
-
-    wave.tz
-
 Calculate the wave peak direction:
 
 .. code-block:: python

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1440,7 +1440,9 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         Calculated from the zeroth- and second-order spectral moments according to:
 
-            ``tz = 2pi * sqrt(m0 / m2)``
+            ``tz = sqrt(m0 / m2)``
+
+        where the spectral moments are calculated by integrating over frequency in Hz.
         """
         m0 = self.moment(0, freq_hz=False)
         m2 = self.moment(2, freq_hz=False)

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1433,6 +1433,19 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         m_n = trapz((f**n) * spectrum, f)
         return m_n
 
+    @property
+    def tz(self):
+        """
+        Mean zero-crossing period, Tz, in 'seconds'.
+
+        Calculated from the zeroth- and second-order spectral moments according to:
+
+            ``tz = 2pi * sqrt(m0 / m2)``
+        """
+        m0 = self.moment(0, freq_hz=False)
+        m2 = self.moment(2, freq_hz=False)
+        return 2.0 * np.pi * np.sqrt(m0 / m2)
+
 
 class WaveSpectrum(DirectionalSpectrum):
     def __repr__(self):
@@ -1449,19 +1462,6 @@ class WaveSpectrum(DirectionalSpectrum):
         """
         m0 = self.moment(0)
         return 4.0 * np.sqrt(m0)
-
-    @property
-    def tz(self):
-        """
-        Mean zero-crossing period, Tz, in 'seconds'.
-
-        Calculated from the zeroth- and second-order spectral moments according to:
-
-            ``tz = 2pi * sqrt(m0 / m2)``
-        """
-        m0 = self.moment(0, freq_hz=False)
-        m2 = self.moment(2, freq_hz=False)
-        return 2.0 * np.pi * np.sqrt(m0 / m2)
 
     @property
     def tp(self):

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1445,7 +1445,7 @@ class WaveSpectrum(DirectionalSpectrum):
 
         Calculated from the zeroth-order spectral moment according to:
 
-            ``hs = 4.0 * np.sqrt(m0)``
+            ``hs = 4.0 * sqrt(m0)``
         """
         m0 = self.moment(0)
         return 4.0 * np.sqrt(m0)

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1470,10 +1470,11 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         Returns
         -------
-        x : float or array
+        x : array
             Extreme value(s).
         """
-        return self.std * np.sqrt(2.0 * np.log((t / self.tz) / np.log(1.0 / q)))
+        q = np.asarray_chkfinite(q)
+        return self.std() * np.sqrt(2.0 * np.log((t / self.tz) / np.log(1.0 / q)))
 
 
 class WaveSpectrum(DirectionalSpectrum):

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1456,9 +1456,9 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         ``x = sigma * sqrt(2 * ln((t / tz) / ln(1 / q)))
 
-        where ``sigma`` is the standard deviation of the process, ``t`` is the observation
-        time in seconds, and ``q`` the quantile. Setting ``q=0.37`` yields the most
-        probable maximum (MPM).
+        where ``sigma`` is the standard deviation of the process, ``t`` is the duration
+        of the process in seconds, and ``q`` is the quantile. Setting ``q=0.37`` yields
+        the most probable maximum (MPM).
 
         Parameters
         ----------
@@ -1470,8 +1470,16 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         Returns
         -------
-        x : array
+        x : float or array
             Extreme value(s).
+
+        Notes
+        -----
+        The method computes extreme values for a single-sided process, where only
+        the crests (or the troughs) are considered. If you are interested in the
+        extremes of either the crests or the troughs, you must increase the duration
+        by a factor of 2.
+
         """
         q = np.asarray_chkfinite(q)
         return self.std() * np.sqrt(2.0 * np.log((t / self.tz) / np.log(1.0 / q)))

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1454,31 +1454,30 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         The extreme value, ``x``, is calculated according to:
 
-        ``x = sigma * sqrt(2 * ln((t / tz) / ln(1 / q)))
+        ``x = sigma * sqrt(2 * ln((t / tz) / ln(1 / q)))``
 
         where ``sigma`` is the standard deviation of the process, ``t`` is the duration
-        of the process in seconds, and ``q`` is the quantile. Setting ``q=0.37`` yields
-        the most probable maximum (MPM).
+        of the process, and ``q`` is the quantile. Setting ``q=0.37`` yields the
+        most probable maximum (MPM).
+
+        The extreme value indicates a level which the maximum value of the process
+        amplitudes will be below with a certain probability. Note that the method
+        only computes extreme values for the maxima, and does not consider the minima.
 
         Parameters
         ----------
         t : float
             Time/duration in seconds for which the of the process is observed.
         q : float or array-like
-            Quantile or sequence of quantiles to compute, which must be between 0
-            and 1 (inclusive).
+            Quantile or sequence of quantiles to compute. Must be between 0 and 1
+            (inclusive).
 
         Returns
         -------
         x : float or array
-            Extreme value(s).
-
-        Notes
-        -----
-        The method computes extreme values for a single-sided process, where only
-        the crests (or the troughs) are considered. If you are interested in the
-        extremes of either the crests or the troughs, you must increase the duration, ``t``,
-        by a factor of 2.
+            Extreme value(s). During the given time period, the maximum value of
+            the process amplitudes will be below the returned value with a given
+            probability.
 
         """
         q = np.asarray_chkfinite(q)

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1457,7 +1457,7 @@ class WaveSpectrum(DirectionalSpectrum):
 
         Calculated from the zeroth- and second-order spectral moments according to:
 
-            ``tz = 2pi * np.sqrt(m0 / m2)``
+            ``tz = 2pi * sqrt(m0 / m2)``
         """
         m0 = self.moment(0, freq_hz=False)
         m2 = self.moment(2, freq_hz=False)

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1477,7 +1477,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         -----
         The method computes extreme values for a single-sided process, where only
         the crests (or the troughs) are considered. If you are interested in the
-        extremes of either the crests or the troughs, you must increase the duration
+        extremes of either the crests or the troughs, you must increase the duration, ``t``,
         by a factor of 2.
 
         """

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1444,9 +1444,9 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         where the spectral moments are calculated by integrating over frequency in Hz.
         """
-        m0 = self.moment(0, freq_hz=False)
-        m2 = self.moment(2, freq_hz=False)
-        return 2.0 * np.pi * np.sqrt(m0 / m2)
+        m0 = self.moment(0, freq_hz=True)
+        m2 = self.moment(2, freq_hz=True)
+        return np.sqrt(m0 / m2)
 
 
 class WaveSpectrum(DirectionalSpectrum):

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1453,15 +1453,15 @@ class WaveSpectrum(DirectionalSpectrum):
     @property
     def tz(self):
         """
-        Mean crossing period, Tz, (sometimes called the mean wave period) in 'seconds'.
+        Mean zero-crossing period, Tz, in 'seconds'.
 
         Calculated from the zeroth- and second-order spectral moments according to:
 
-            ``tz = np.sqrt(m0 / m2)``
+            ``tz = 2pi * np.sqrt(m0 / m2)``
         """
         m0 = self.moment(0, freq_hz=False)
-        m2 = self.moment(2, freq_hz=True)
-        return np.sqrt(m0 / m2)
+        m2 = self.moment(2, freq_hz=False)
+        return 2.0 * np.pi * np.sqrt(m0 / m2)
 
     @property
     def tp(self):

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1448,6 +1448,33 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         m2 = self.moment(2, freq_hz=True)
         return np.sqrt(m0 / m2)
 
+    def extreme(self, t, q=0.37):
+        """
+        Compute the q-th quantile extreme value (assuming a Gaussian process).
+
+        The extreme value, ``x``, is calculated according to:
+
+        ``x = sigma * sqrt(2 * ln((t / tz) / ln(1 / q)))
+
+        where ``sigma`` is the standard deviation of the process, ``t`` is the observation
+        time in seconds, and ``q`` the quantile. Setting ``q=0.37`` yields the most
+        probable maximum (MPM).
+
+        Parameters
+        ----------
+        t : float
+            Time/duration in seconds for which the of the process is observed.
+        q : float or array-like
+            Quantile or sequence of quantiles to compute, which must be between 0
+            and 1 (inclusive).
+
+        Returns
+        -------
+        x : float or array
+            Extreme value(s).
+        """
+        return self.std * np.sqrt(2.0 * np.log((t / self.tz) / np.log(1.0 / q)))
+
 
 class WaveSpectrum(DirectionalSpectrum):
     def __repr__(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3382,7 +3382,7 @@ class Test_DirectionalSpectrum:
         sigma = spectrum.std()
         tz = spectrum.tz
 
-        T = 360 * 24 * 60.0 ** 2
+        T = 360 * 24 * 60.0**2
         q = 0.99
         extreme_out = spectrum.extreme(T, q=q)
 
@@ -3402,7 +3402,7 @@ class Test_DirectionalSpectrum:
         sigma = spectrum.std()
         tz = spectrum.tz
 
-        T = 360 * 24 * 60.0 ** 2
+        T = 360 * 24 * 60.0**2
         q = [0.1, 0.5, 0.99]
         extreme_out = spectrum.extreme(T, q=q)
 
@@ -3426,7 +3426,7 @@ class Test_DirectionalSpectrum:
         sigma = spectrum.std()
         tz = spectrum.tz
 
-        T = 360 * 24 * 60.0 ** 2
+        T = 360 * 24 * 60.0**2
         extreme_out = spectrum.extreme(T, q=0.37)
 
         extreme_expect = sigma * np.sqrt(2.0 * np.log(T / tz))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3370,6 +3370,78 @@ class Test_DirectionalSpectrum:
         with pytest.raises(AttributeError):
             directional_spectrum.imag
 
+    def test_extreme_float(self):
+        y0 = 0.0
+        y1 = 2
+        a = 7
+        b = 6
+
+        y = np.linspace(y0, y1, 20)
+        x = np.arange(5, 360, 10)
+        v = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
+
+        spectrum = DirectionalSpectrum(y, x, v, freq_hz=True, degrees=True)
+
+        sigma = spectrum.std()
+        tz = spectrum.tz
+
+        T = 360 * 24 * 60.0 ** 2
+        q = 0.99
+        extreme_out = spectrum.extreme(T, q=q)
+
+        extreme_expect = sigma * np.sqrt(2.0 * np.log((T / tz) / np.log(1.0 / q)))
+
+        assert extreme_out == pytest.approx(extreme_expect)
+
+    def test_extreme_list(self):
+        y0 = 0.0
+        y1 = 2
+        a = 7
+        b = 6
+
+        y = np.linspace(y0, y1, 20)
+        x = np.arange(5, 360, 10)
+        v = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
+
+        spectrum = DirectionalSpectrum(y, x, v, freq_hz=True, degrees=True)
+
+        sigma = spectrum.std()
+        tz = spectrum.tz
+
+        T = 360 * 24 * 60.0 ** 2
+        q = [0.1, 0.5, 0.99]
+        extreme_out = spectrum.extreme(T, q=q)
+
+        extreme_expect = [
+            sigma * np.sqrt(2.0 * np.log((T / tz) / np.log(1.0 / q[0]))),
+            sigma * np.sqrt(2.0 * np.log((T / tz) / np.log(1.0 / q[1]))),
+            sigma * np.sqrt(2.0 * np.log((T / tz) / np.log(1.0 / q[2]))),
+        ]
+
+        np.testing.assert_array_almost_equal(extreme_out, extreme_expect)
+
+    def test_extreme_mpm(self):
+        y0 = 0.0
+        y1 = 2
+        a = 7
+        b = 6
+
+        y = np.linspace(y0, y1, 20)
+        x = np.arange(5, 360, 10)
+        v = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
+
+        spectrum = DirectionalSpectrum(y, x, v, freq_hz=True, degrees=True)
+
+        sigma = spectrum.std()
+        tz = spectrum.tz
+
+        T = 360 * 24 * 60.0 ** 2
+        extreme_out = spectrum.extreme(T, q=0.37)
+
+        extreme_expect = sigma * np.sqrt(2.0 * np.log(T / tz))
+
+        assert extreme_out == pytest.approx(extreme_expect, rel=0.01)
+
 
 class Test_WaveSpectrum:
     def test__init__(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3284,6 +3284,24 @@ class Test_DirectionalSpectrum:
         # not exactly same due to error in trapz for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)
 
+    def test_tz(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = np.ones((len(freq), len(dirs)))
+        spectrum = DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+        tz_out = spectrum.tz
+
+        m0 = (0.0 - 360.0) * (f0 - f1)
+        m2 = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3)
+
+        tz_expect = np.sqrt(m0 / m2)
+
+        assert tz_out == pytest.approx(tz_expect, rel=0.1)
+
     def test_from_grid(self):
         freq = np.linspace(0, 1.0, 10)
         dirs = np.linspace(0, 360.0, 15, endpoint=False)
@@ -3427,24 +3445,6 @@ class Test_WaveSpectrum:
         hs_expect = 4.0 * np.sqrt((0.0 - 360.0) * (f0 - f1))
 
         assert hs_out == pytest.approx(hs_expect)
-
-    def test_tz(self):
-        f0 = 0.0
-        f1 = 2.0
-
-        freq = np.linspace(f0, f1, 20)
-        dirs = np.arange(5, 360, 10)
-        vals = np.ones((len(freq), len(dirs)))
-        wave = WaveSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
-
-        tz_out = wave.tz
-
-        m0 = (0.0 - 360.0) * (f0 - f1)
-        m2 = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3)
-
-        tz_expect = np.sqrt(m0 / m2)
-
-        assert tz_out == pytest.approx(tz_expect, rel=0.1)
 
     def test_tp_hz(self):
         freq = np.linspace(0, 2, 20)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3371,16 +3371,13 @@ class Test_DirectionalSpectrum:
             directional_spectrum.imag
 
     def test_extreme_float(self):
-        y0 = 0.0
-        y1 = 2
-        a = 7
-        b = 6
+        f0 = 0.0
+        f1 = 2.0
 
-        y = np.linspace(y0, y1, 20)
-        x = np.arange(5, 360, 10)
-        v = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        spectrum = DirectionalSpectrum(y, x, v, freq_hz=True, degrees=True)
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = np.ones((len(freq), len(dirs)))
+        spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
         sigma = spectrum.std()
         tz = spectrum.tz
@@ -3394,16 +3391,13 @@ class Test_DirectionalSpectrum:
         assert extreme_out == pytest.approx(extreme_expect)
 
     def test_extreme_list(self):
-        y0 = 0.0
-        y1 = 2
-        a = 7
-        b = 6
+        f0 = 0.0
+        f1 = 2.0
 
-        y = np.linspace(y0, y1, 20)
-        x = np.arange(5, 360, 10)
-        v = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        spectrum = DirectionalSpectrum(y, x, v, freq_hz=True, degrees=True)
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = np.ones((len(freq), len(dirs)))
+        spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
         sigma = spectrum.std()
         tz = spectrum.tz
@@ -3421,16 +3415,13 @@ class Test_DirectionalSpectrum:
         np.testing.assert_array_almost_equal(extreme_out, extreme_expect)
 
     def test_extreme_mpm(self):
-        y0 = 0.0
-        y1 = 2
-        a = 7
-        b = 6
+        f0 = 0.0
+        f1 = 2.0
 
-        y = np.linspace(y0, y1, 20)
-        x = np.arange(5, 360, 10)
-        v = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        spectrum = DirectionalSpectrum(y, x, v, freq_hz=True, degrees=True)
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = np.ones((len(freq), len(dirs)))
+        spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
         sigma = spectrum.std()
         tz = spectrum.tz
@@ -3440,7 +3431,7 @@ class Test_DirectionalSpectrum:
 
         extreme_expect = sigma * np.sqrt(2.0 * np.log(T / tz))
 
-        assert extreme_out == pytest.approx(extreme_expect, rel=0.01)
+        assert extreme_out == pytest.approx(extreme_expect, rel=1e-3)
 
 
 class Test_WaveSpectrum:


### PR DESCRIPTION
### This PR is related to user story DST-348

## Description
Added a method called `DirectionalSpectrum.extreme()`, which computes extreme values for a spectrum.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
