### PR TITLE
Extend extreme method to accept absolute value extremes

### DIFF
--- a/docs/user_guide/concepts_utils/directional_spectrum.rst
+++ b/docs/user_guide/concepts_utils/directional_spectrum.rst
@@ -80,12 +80,18 @@ Calculate the mean zero-crossing period, Tz:
     spectrum.tz
 
 Calculate extreme values using the :meth:`~waveresponse.DirectionalSpectrum.extreme`
-method. The method takes two arguments: the duration of the process (in seconds),
-and a quantile, ``q``.
+method. The method takes three arguments: the duration of the process (in seconds),
+the quantile, ``q``, and a boolean flag, ``absmax``, determining whether to compute absolute
+value extremes (or only consider the maxima (`default`)).
 
 .. code-block:: python
 
     duration = 3 * 3600   # 3 hours
 
+    # Extreme maximum
     mpm = spectrum.extreme(duration, q=0.37)   # most probable maximum (MPM)
     q90 = spectrum.extreme(duration, q=0.90)   # 90-th quantile
+
+    # Extreme absolute value maximum (i.e., minima are taken into account)
+    mpm = spectrum.extreme(duration, q=0.37, absmax=True)   # most probable maximum (MPM)
+    q90 = spectrum.extreme(duration, q=0.90, absmax=True)   # 90-th quantile

--- a/docs/user_guide/standardized_spectra.rst
+++ b/docs/user_guide/standardized_spectra.rst
@@ -167,7 +167,7 @@ Torsethaugen
 ------------
 The *Torsethaugen* spectrum allows you to set up a double-peaked spectrum that represents
 sea states which includes both a remotely generated swell component (with low frequency energy)
-and a locally generated wind component (with high frequency energy). The spectral spectral model
+and a locally generated wind component (with high frequency energy). The spectral model
 was developed based on average measured spectra for Norwegian waters (Haltenbanken and Statfjord).
 The Torsethaugen spectrum is described by two parameter (i.e. :math:`H_s` and :math:`T_p`), and
 is given by:

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1448,7 +1448,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         m2 = self.moment(2, freq_hz=True)
         return np.sqrt(m0 / m2)
 
-    def extreme(self, t, q=0.37):
+    def extreme(self, t, q=0.37, absmax=False):
         """
         Compute the q-th quantile extreme value (assuming a Gaussian process).
 
@@ -1471,6 +1471,9 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         q : float or array-like
             Quantile or sequence of quantiles to compute. Must be between 0 and 1
             (inclusive).
+        absmax : bool
+            Weather to compute absolute value extremes (i.e., taking the minima into account).
+            If ``False`` (default), only the maxima are considered.
 
         Returns
         -------
@@ -1480,6 +1483,9 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
             probability.
 
         """
+        if absmax:
+            t *= 2.0
+
         q = np.asarray_chkfinite(q)
         return self.std() * np.sqrt(2.0 * np.log((t / self.tz) / np.log(1.0 / q)))
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1468,7 +1468,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
             Quantile or sequence of quantiles to compute. Must be between 0 and 1
             (inclusive).
         absmax : bool
-            Weather to compute absolute value extremes (i.e., taking the minima into account).
+            Whether to compute absolute value extremes (i.e., taking the minima into account).
             If ``False`` (default), only the maxima are considered. See Notes.
 
         Returns

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1481,7 +1481,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         Notes
         -----
         Computing absolute value extremes by setting ``absmax=True`` is equivalent
-        to doubling the zero-crossing rate, ``fz = 1 / Tz``.
+        to doubling the expected zero-crossing rate, ``fz = 1 / Tz``.
 
         """
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1460,10 +1460,6 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         of the process, and ``q`` is the quantile. Setting ``q=0.37`` yields the
         most probable maximum (MPM).
 
-        The extreme value indicates a level which the maximum value of the process
-        amplitudes will be below with a certain probability. Note that the method
-        only computes extreme values for the maxima, and does not consider the minima.
-
         Parameters
         ----------
         t : float
@@ -1473,14 +1469,19 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
             (inclusive).
         absmax : bool
             Weather to compute absolute value extremes (i.e., taking the minima into account).
-            If ``False`` (default), only the maxima are considered.
+            If ``False`` (default), only the maxima are considered. See Notes.
 
         Returns
         -------
         x : float or array
-            Extreme value(s). During the given time period, the maximum value of
-            the process amplitudes will be below the returned value with a given
-            probability.
+            Extreme value(s). During the given time period, the maximum value (or
+            absolute value maximum) of the process amplitudes will be below the
+            returned value with the given probability.
+
+        Notes
+        -----
+        Computing absolute value extremes by setting ``absmax=True`` is equivalent
+        to doubling the duration, ``t``.
 
         """
         if absmax:

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1481,7 +1481,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         Notes
         -----
         Computing absolute value extremes by setting ``absmax=True`` is equivalent
-        to doubling the duration, ``t``.
+        to doubling the zero-crossing frequency, ``fz = 1 / Tz``.
 
         """
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1481,7 +1481,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         Notes
         -----
         Computing absolute value extremes by setting ``absmax=True`` is equivalent
-        to doubling the zero-crossing frequency, ``fz = 1 / Tz``.
+        to doubling the zero-crossing rate, ``fz = 1 / Tz``.
 
         """
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1484,11 +1484,14 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         to doubling the duration, ``t``.
 
         """
+
         if absmax:
-            t *= 2.0
+            tz = self.tz / 2.0
+        else:
+            tz = self.tz
 
         q = np.asarray_chkfinite(q)
-        return self.std() * np.sqrt(2.0 * np.log((t / self.tz) / np.log(1.0 / q)))
+        return self.std() * np.sqrt(2.0 * np.log((t / tz) / np.log(1.0 / q)))
 
 
 class WaveSpectrum(DirectionalSpectrum):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3433,6 +3433,27 @@ class Test_DirectionalSpectrum:
 
         assert extreme_out == pytest.approx(extreme_expect, rel=1e-3)
 
+    def test_extreme_absmax(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = np.ones((len(freq), len(dirs)))
+        spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+        sigma = spectrum.std()
+        tz = spectrum.tz
+
+        T = 360 * 24 * 60.0**2
+        q = 0.99
+        extreme_out = spectrum.extreme(T, q=q, absmax=True)
+
+        T_ = 2.0 * T
+        extreme_expect = sigma * np.sqrt(2.0 * np.log((T_ / tz) / np.log(1.0 / q)))
+
+        assert extreme_out == pytest.approx(extreme_expect)
+
 
 class Test_WaveSpectrum:
     def test__init__(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3379,12 +3379,12 @@ class Test_DirectionalSpectrum:
         vals = np.ones((len(freq), len(dirs)))
         spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
-        sigma = spectrum.std()
-        tz = spectrum.tz
-
         T = 360 * 24 * 60.0**2
         q = 0.99
         extreme_out = spectrum.extreme(T, q=q)
+
+        sigma = spectrum.std()
+        tz = spectrum.tz
 
         extreme_expect = sigma * np.sqrt(2.0 * np.log((T / tz) / np.log(1.0 / q)))
 
@@ -3399,12 +3399,12 @@ class Test_DirectionalSpectrum:
         vals = np.ones((len(freq), len(dirs)))
         spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
-        sigma = spectrum.std()
-        tz = spectrum.tz
-
         T = 360 * 24 * 60.0**2
         q = [0.1, 0.5, 0.99]
         extreme_out = spectrum.extreme(T, q=q)
+
+        sigma = spectrum.std()
+        tz = spectrum.tz
 
         extreme_expect = [
             sigma * np.sqrt(2.0 * np.log((T / tz) / np.log(1.0 / q[0]))),
@@ -3423,11 +3423,11 @@ class Test_DirectionalSpectrum:
         vals = np.ones((len(freq), len(dirs)))
         spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
-        sigma = spectrum.std()
-        tz = spectrum.tz
-
         T = 360 * 24 * 60.0**2
         extreme_out = spectrum.extreme(T, q=0.37)
+
+        sigma = spectrum.std()
+        tz = spectrum.tz
 
         extreme_expect = sigma * np.sqrt(2.0 * np.log(T / tz))
 
@@ -3442,15 +3442,14 @@ class Test_DirectionalSpectrum:
         vals = np.ones((len(freq), len(dirs)))
         spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
-        sigma = spectrum.std()
-        tz = spectrum.tz
-
         T = 360 * 24 * 60.0**2
         q = 0.99
         extreme_out = spectrum.extreme(T, q=q, absmax=True)
 
-        T_ = 2.0 * T
-        extreme_expect = sigma * np.sqrt(2.0 * np.log((T_ / tz) / np.log(1.0 / q)))
+        sigma = spectrum.std()
+        tz_absmax = spectrum.tz / 2.0
+
+        extreme_expect = sigma * np.sqrt(2.0 * np.log((T / tz_absmax) / np.log(1.0 / q)))
 
         assert extreme_out == pytest.approx(extreme_expect)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -73,7 +73,6 @@ def rao(freq_dirs):
 
 @pytest.fixture
 def rao_for_mirroring():
-
     freq = np.linspace(0, 1.0, 3)
     dirs = np.linspace(0, 180, 3, endpoint=True)
     vals = np.array(
@@ -141,7 +140,6 @@ def test_sort():
 
 
 class Test__robust_modulus:
-
     params_robust_modulus = [
         (2.5, 2.0, 0.5),
         (2.0, 2.0, 0.0),
@@ -656,7 +654,6 @@ class Test_mirror:
 
 
 class Test__check_foldable:
-
     check_foldable_valid = [
         (
             np.linspace(
@@ -1408,7 +1405,6 @@ class Test_Grid:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_interpolate_fill_value(self):
-
         freq = np.array([0, 1, 2])
         dirs = np.array([0, 90, 180, 270])
         vals = np.array(
@@ -1433,7 +1429,6 @@ class Test_Grid:
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_interpolate_fill_value_None(self):
-
         freq = np.array([0, 1, 2])
         dirs = np.array([0, 90, 180, 270])
         vals = np.array(
@@ -3449,7 +3444,9 @@ class Test_DirectionalSpectrum:
         sigma = spectrum.std()
         tz_absmax = spectrum.tz / 2.0
 
-        extreme_expect = sigma * np.sqrt(2.0 * np.log((T / tz_absmax) / np.log(1.0 / q)))
+        extreme_expect = sigma * np.sqrt(
+            2.0 * np.log((T / tz_absmax) / np.log(1.0 / q))
+        )
 
         assert extreme_out == pytest.approx(extreme_expect)
 


### PR DESCRIPTION
### This PR is related to user story DST-385

## Description
Included an ``absmax`` flag, giving the option to compute absolute value extremes.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
