### PR TITLE
Pin numpy version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 
-### This PR is related to user story DST-
+### This PR is related to user story [ESS-XXXX](url_to_jira_task)
 
 ## Description
 Provide a short description about the work that has been done.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"] 
+        python-version: ["3.9", "3.10", "3.11"] 
 
     steps:
       - uses: actions/checkout@v2
@@ -36,4 +36,4 @@ jobs:
 
       - name: Test doc build with tox
         run: tox -e docs
-        if: ${{ (matrix.python-version == '3.9') && (matrix.os == 'ubuntu-latest')}}
+        if: ${{ (matrix.python-version == '3.10') && (matrix.os == 'ubuntu-latest')}}

--- a/.github/workflows/deploy_public.yml
+++ b/.github/workflows/deploy_public.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,17 +11,17 @@ dynamic = ["version"]
 description = "Vessel motion and wave utilities"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Unix", 
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "numpy",
+    "numpy<2.0.0",
     "pandas",
     "scipy",
 ]
@@ -53,7 +53,7 @@ deps =
     pytest-cov
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3.10
 commands = sphinx-build -W -b html -d {toxworkdir}/docs_doctree docs {toxworkdir}/docs_out
 deps =
     sphinx==5.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "numpy<2.0.0",
     "pandas",
     "scipy",
+    "pyarrow"
 ]
 
 [project.urls]

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from numbers import Number
 
 import numpy as np
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 from scipy.interpolate import interp2d
 from scipy.special import gamma
 
@@ -1392,7 +1392,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         x = self._full_range_dir(self._dirs)
         y = self._freq
         zz = self.interpolate(y, x, freq_hz=False, degrees=False)
-        return trapz([trapz(zz_x, x) for zz_x in zz], y)
+        return trapezoid([trapezoid(zz_x, x) for zz_x in zz], y)
 
     def std(self):
         """
@@ -1452,7 +1452,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         else:
             raise ValueError("'axis' must be 0 or 1.")
 
-        spectrum = np.array([trapz(zz_y, y) for zz_y in zz])
+        spectrum = np.array([trapezoid(zz_y, y) for zz_y in zz])
         return x, spectrum
 
     def moment(self, n, freq_hz=None):
@@ -1484,7 +1484,7 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         """
         f, spectrum = self.spectrum1d(axis=1, freq_hz=freq_hz)
-        m_n = trapz((f**n) * spectrum, f)
+        m_n = trapezoid((f**n) * spectrum, f)
         return m_n
 
     @property
@@ -1618,8 +1618,8 @@ class WaveSpectrum(DirectionalSpectrum):
         spectrum : array-like
             1-D spectrum directional distribution.
         """
-        sin = trapz(np.sin(dirs) * spectrum, dirs)
-        cos = trapz(np.cos(dirs) * spectrum, dirs)
+        sin = trapezoid(np.sin(dirs) * spectrum, dirs)
+        cos = trapezoid(np.cos(dirs) * spectrum, dirs)
         return _robust_modulus(np.arctan2(sin, cos), 2.0 * np.pi)
 
     def dirp(self, degrees=None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3346,7 +3346,7 @@ class Test_DirectionalSpectrum:
 
         m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3)
 
-        # not exactly same due to error in trapz for higher order functions
+        # not exactly same due to error in trapezoid for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)
 
     def test_moment_m2_rads(self):
@@ -3364,7 +3364,7 @@ class Test_DirectionalSpectrum:
             (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2
         )
 
-        # not exactly same due to error in trapz for higher order functions
+        # not exactly same due to error in trapezoid for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)
 
     def test_tz(self):

--- a/tests/test_standardized1d.py
+++ b/tests/test_standardized1d.py
@@ -182,10 +182,10 @@ class Test_ModifiedPiersonMoskowitz:
         spectrum = wr.ModifiedPiersonMoskowitz(freq)
 
         freq_rad, ps_rad = spectrum(3.5, 10.0, freq_hz=False)
-        var_rad = integrate.trapz(ps_rad, freq_rad)
+        var_rad = integrate.trapezoid(ps_rad, freq_rad)
 
         freq_hz, ps_hz = spectrum(3.5, 10.0, freq_hz=True)
-        var_hz = integrate.trapz(ps_hz, freq_hz)
+        var_hz = integrate.trapezoid(ps_hz, freq_hz)
 
         assert var_rad == pytest.approx(var_hz)
 
@@ -212,10 +212,10 @@ class Test_JONSWAP:
         spectrum = wr.JONSWAP(freq)
 
         freq_rad, ps_rad = spectrum(3.5, 10.0, freq_hz=False)
-        var_rad = integrate.trapz(ps_rad, freq_rad)
+        var_rad = integrate.trapezoid(ps_rad, freq_rad)
 
         freq_hz, ps_hz = spectrum(3.5, 10.0, freq_hz=True)
-        var_hz = integrate.trapz(ps_hz, freq_hz)
+        var_hz = integrate.trapezoid(ps_hz, freq_hz)
 
         assert var_rad == pytest.approx(var_hz)
 
@@ -385,10 +385,10 @@ class Test_OchiHubble:
         spectrum = wr.OchiHubble(freq)
 
         freq_rad, ps_rad = spectrum(3.5, 10.0, freq_hz=False)
-        var_rad = integrate.trapz(ps_rad, freq_rad)
+        var_rad = integrate.trapezoid(ps_rad, freq_rad)
 
         freq_hz, ps_hz = spectrum(3.5, 10.0, freq_hz=True)
-        var_hz = integrate.trapz(ps_hz, freq_hz)
+        var_hz = integrate.trapezoid(ps_hz, freq_hz)
 
         assert var_rad == pytest.approx(var_hz)
 
@@ -598,10 +598,10 @@ class Test_Torsethaugen:
         spectrum = wr.Torsethaugen(freq)
 
         freq_rad, ps_rad = spectrum(3.5, 10.0, freq_hz=False)
-        var_rad = integrate.trapz(ps_rad, freq_rad)
+        var_rad = integrate.trapezoid(ps_rad, freq_rad)
 
         freq_hz, ps_hz = spectrum(3.5, 10.0, freq_hz=True)
-        var_hz = integrate.trapz(ps_hz, freq_hz)
+        var_hz = integrate.trapezoid(ps_hz, freq_hz)
 
         assert var_rad == pytest.approx(var_hz)
 


### PR DESCRIPTION
### This PR is related to user story [ESS-2278](https://4insight.atlassian.net/jira/software/c/projects/ESS/boards/34?selectedIssue=ESS-2278)

## Description
Changes: 
- Update pythonversion
- Lock numpy
- Handle deprecation warnings

Deprecation warnings that have been handled:
- Added pyarrow-dependency do to this warning:
Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0)

- Trapz -> trapezoid (just change of name, same functionality)


## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used



[ESS-2278]: https://4insight.atlassian.net/browse/ESS-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ