### PR TITLE
Added a band-pass method

### DIFF
--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -774,6 +774,40 @@ class Grid:
         new._freq, new._dirs, new._vals = freq_new, dirs_new, vals_new
         return new
 
+    def bandpassed(self, freq_min = None, freq_max = None):
+        """
+        Apply a bandpass filter to keep only the energy between the given frequencies [Hz].
+
+        A new object is returned where the grid is modified such that
+        - the bandpassed frequencies are included
+        - the frequencies outside the bandpass are removed
+
+        """
+
+        freq_hz = self.freq(freq_hz=True)
+
+        if freq_min is None:
+            freq_min = min(freq_hz)
+        if freq_max is None:
+            freq_max = max(freq_hz)
+
+        assert freq_min < freq_max, "freq_min must be less than freq_max"
+        assert freq_min >= min(freq_hz), "freq_min must be greater than or equal to the minimum frequency in the grid"
+        assert freq_max <= max(freq_hz), "freq_max must be less than or equal to the maximum frequency in the grid"
+
+        new_freq = np.unique([*freq_hz, freq_min, freq_max])
+        new_freq.sort()
+        new_freq = new_freq[(new_freq >= freq_min) & (new_freq <= freq_max)]
+
+        return self.reshape(freq = new_freq,
+                            dirs = self.dirs(degrees=True),
+                            freq_hz = True,
+                            degrees = True)
+
+
+
+
+
     def __mul__(self, other):
         """
         Multiply values (element-wise).


### PR DESCRIPTION
### This PR is related to user story [ESS-XXXX](url_to_jira_task) ?

## Description
Added a bandpass method to analyze energy contents of waves.

I'm creating a package [WaveDave](https://github.com/RubendeBruin/WaveDave) that combines the power of wavesresponse and wavespectra.

It can be used to visualize metocean data and the result of that on the expected / measured responses. One of the example outputs is:

![image](https://github.com/4Subsea/waveresponse-python/assets/34062862/3f99ec42-cfe1-442b-91e2-36b0182c0e93)

this requires bandpassing the wave-spectra.

## Checklist
- [X] PR title is descriptive and fit for injection into release notes (see tips below)
- [X] Correct label(s) are used

