### PR TITLE
Pin scipy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "numpy<2.0.0",
     "pandas",
-    "scipy",
+    "scipy<1.14.0",
     "pyarrow"
 ]
 

--- a/src/waveresponse/_standardized1d.py
+++ b/src/waveresponse/_standardized1d.py
@@ -556,9 +556,7 @@ class Torsethaugen(BaseSpectrum1d):
         A_secondary = (3.26 / 16.0) * hs_secondary**2 * omega_p_secondary**3
         B_secondary = omega_p_secondary**4
 
-        spectrum_secondary = (
-            A_secondary / omega**4 * np.exp(-B_secondary / omega**4)
-        )
+        spectrum_secondary = A_secondary / omega**4 * np.exp(-B_secondary / omega**4)
 
         return spectrum_primary + spectrum_secondary
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3360,9 +3360,7 @@ class Test_DirectionalSpectrum:
 
         m_out = spectrum.moment(2, freq_hz=False)
 
-        m_expect = (
-            (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2
-        )
+        m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2
 
         # not exactly same due to error in trapezoid for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)


### PR DESCRIPTION
### This PR is related to user story [ESS-XXXX](url_to_jira_task)

## Description
Scipy 1.14.0 deprecates [interp2d ](https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html), causing the waveresponse to fail on import. This is a quick fix, pinning the scipy version.


## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


