### PR TITLE
Fix numerical precision issue when comparing frequencies and directions between Grid-like objects 

### DIFF
--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -104,9 +104,9 @@ def _check_is_similar(*grids, exact_type=True):
             raise TypeError("Object types are not similar.")
         elif grid_ref._vals.shape != grid_i._vals.shape:
             raise ValueError("Grid objects have different shape.")
-        elif not np.allclose(grid_ref._freq, grid_i._freq) or not np.allclose(
-            grid_ref._dirs, grid_i._dirs
-        ):
+        elif not np.allclose(
+            grid_ref._freq, grid_i._freq, atol=1e-8, rtol=0.0
+        ) or not np.allclose(grid_ref._dirs, grid_i._dirs, atol=1e-8, rtol=0.0):
             raise ValueError(
                 "Grid objects have different frequency/direction coordinates."
             )

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -104,8 +104,8 @@ def _check_is_similar(*grids, exact_type=True):
             raise TypeError("Object types are not similar.")
         elif grid_ref._vals.shape != grid_i._vals.shape:
             raise ValueError("Grid objects have different shape.")
-        elif np.any(grid_ref._freq != grid_i._freq) or np.any(
-            grid_ref._dirs != grid_i._dirs
+        elif not np.allclose(grid_ref._freq, grid_i._freq) or not np.allclose(
+            grid_ref._dirs, grid_i._dirs
         ):
             raise ValueError(
                 "Grid objects have different frequency/direction coordinates."


### PR DESCRIPTION
### This PR is related to user story

## Description
Replace exact comparison with `np.allclose(..., atol=1e-8, rtol=0)`.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
