### PR TITLE
Improve phase interpolation when using "polar" interpolation method

### DIFF
--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -685,13 +685,6 @@ class Grid:
         -------
         array :
             Interpolated grid values.
-
-        Notes
-        -----
-        Apply 'polar' interpolation with caution as phase values are not "unwraped"
-        before interpolation. This may lead to some unexpected artifacts in the
-        results.
-
         """
         freq = np.asarray_chkfinite(freq).reshape(-1)
         dirs = np.asarray_chkfinite(dirs).reshape(-1)

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -623,12 +623,13 @@ class Grid:
             return RGI((xp, yp), zp.T, **kw)
         elif complex_convert.lower() == "polar":
             amp, phase = complex_to_polar(zp, phase_degrees=False)
+            phase_complex = np.cos(phase) + 1j * np.sin(phase)
             interp_amp = RGI((xp, yp), amp.T, **kw)
-            interp_phase = RGI((xp, yp), phase.T, **kw)
+            interp_phase = RGI((xp, yp), phase_complex.T, **kw)
             return lambda *args, **kwargs: (
                 polar_to_complex(
                     interp_amp(*args, **kwargs),
-                    interp_phase(*args, **kwargs),
+                    np.angle(interp_phase(*args, **kwargs)),
                     phase_degrees=False,
                 )
             )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from scipy.integrate import quad
+from scipy.interpolate import RegularGridInterpolator as RGI
 
 import waveresponse as wr
 from waveresponse import (
@@ -1503,12 +1504,13 @@ class Test_Grid:
         vals_amp_expect = np.array(
             [[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y]
         )
-        vals_phase_expect = np.array(
-            [[a_phase * x_i + b_phase * y_i for x_i in x] for y_i in y]
-        )
+        x_, y_ = np.meshgrid(x, y, indexing="ij", sparse=True)
+        vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
+        vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
+
         vals_expect = vals_amp_expect * (
-            np.cos(vals_phase_expect) + 1j * np.sin(vals_phase_expect)
-        )
+            vals_phase_cos_expect + 1j * vals_phase_sin_expect
+        ) / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
 
         vals_out = grid.interpolate(
             y, x, freq_hz=True, degrees=True, complex_convert="polar"
@@ -1692,12 +1694,13 @@ class Test_Grid:
         vals_amp_expect = np.array(
             [[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y]
         )
-        vals_phase_expect = np.array(
-            [[a_phase * x_i + b_phase * y_i for x_i in x] for y_i in y]
-        )
+        x_, y_ = np.meshgrid(x, y, indexing="ij", sparse=True)
+        vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
+        vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
+
         vals_expect = vals_amp_expect * (
-            np.cos(vals_phase_expect) + 1j * np.sin(vals_phase_expect)
-        )
+            vals_phase_cos_expect + 1j * vals_phase_sin_expect
+        ) / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
 
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1498,8 +1498,8 @@ class Test_Grid:
         vp = vp_amp * (np.cos(vp_phase) + 1j * np.sin(vp_phase))
         grid = Grid(yp, xp, vp, freq_hz=True, degrees=True)
 
-        y = np.linspace(0.5, 1.0, 20)
-        x = np.linspace(5.0, 15.0, 10)
+        y = np.linspace(0.0, 2.0, 200)
+        x = np.linspace(0.0, 359.0, 100)
         vals_amp_expect = np.array(
             [[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y]
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1508,9 +1508,11 @@ class Test_Grid:
         vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
         vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
 
-        vals_expect = vals_amp_expect * (
-            vals_phase_cos_expect + 1j * vals_phase_sin_expect
-        ) / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        vals_expect = (
+            vals_amp_expect
+            * (vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+            / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        )
 
         vals_out = grid.interpolate(
             y, x, freq_hz=True, degrees=True, complex_convert="polar"
@@ -1698,9 +1700,11 @@ class Test_Grid:
         vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
         vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
 
-        vals_expect = vals_amp_expect * (
-            vals_phase_cos_expect + 1j * vals_phase_sin_expect
-        ) / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        vals_expect = (
+            vals_amp_expect
+            * (vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+            / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        )
 
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)


### PR DESCRIPTION
### This PR is related to user story

## Description
Improves the "polar" interpolation method for the `Grid` class. Interpolates angle in the complex plane instead of the "apparent" value.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
