### PR TITLE
Allow negative complex-valued DirectionalSpectrum

### DIFF
--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1515,7 +1515,9 @@ class DirectionalSpectrum(Grid):
 
         """
         if np.iscomplex(self._vals).any() or (self._vals < 0.0).any():
-            raise ValueError("Mean zero-crossing period is only defined for positive real-valued spectra.")
+            raise ValueError(
+                "Mean zero-crossing period is only defined for positive real-valued spectra."
+            )
 
         m0 = self.moment(0, freq_hz=True)
         m2 = self.moment(2, freq_hz=True)
@@ -1612,6 +1614,7 @@ class WaveSpectrum(DisableComplexMixin, DirectionalSpectrum):
         If waves are 'coming from' the given directions. If ``False``, 'going towards'
         convention is assumed.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1151,7 +1151,7 @@ class RAO(Grid):
         return "RAO"
 
 
-class DirectionalSpectrum(DisableComplexMixin, Grid):
+class DirectionalSpectrum(Grid):
     """
     Directional spectrum.
 
@@ -1210,11 +1210,6 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
 
         if degrees:
             self._vals = 180.0 / np.pi * self._vals
-
-        if np.any(np.iscomplex(self._vals)):
-            raise ValueError("Spectrum values can not be complex.")
-        elif np.any(self._vals < 0.0):
-            raise ValueError("Spectrum values must be positive.")
 
     @classmethod
     def from_spectrum1d(
@@ -1499,7 +1494,8 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
     @property
     def tz(self):
         """
-        Mean zero-crossing period, Tz, in 'seconds'.
+        Mean zero-crossing period, Tz, in 'seconds'. Only applicable for
+        positive real-valued spectra.
 
         Calculated from the zeroth- and second-order spectral moments according to:
 
@@ -1518,13 +1514,18 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         Cambridge University Press.
 
         """
+        if np.iscomplex(self._vals).any() or (self._vals < 0.0).any():
+            raise ValueError("Mean zero-crossing period is only defined for positive real-valued spectra.")
+
         m0 = self.moment(0, freq_hz=True)
         m2 = self.moment(2, freq_hz=True)
+
         return np.sqrt(m0 / m2)
 
     def extreme(self, t, q=0.37, absmax=False):
         """
         Compute the q-th quantile extreme value (assuming a Gaussian process).
+        Only applicable for positive real-valued spectra.
 
         The extreme value, ``x``, is calculated according to:
 
@@ -1577,7 +1578,48 @@ class DirectionalSpectrum(DisableComplexMixin, Grid):
         return self.std() * np.sqrt(2.0 * np.log((t / tz) / np.log(1.0 / q)))
 
 
-class WaveSpectrum(DirectionalSpectrum):
+class WaveSpectrum(DisableComplexMixin, DirectionalSpectrum):
+    """
+    Wave spectrum.
+
+    The ``WaveSpectrum`` class extends the :class:`~waveresponse.DirectionalSpectrum`
+    class, and is a two-dimentional frequency/(wave)direction grid. The spectrum values
+    represents spectrum density. Only real and positive values allowed.
+
+    Proper scaling is performed such that the total "energy" is kept constant at
+    all times.
+
+
+    Parameters
+    ----------
+    freq : array-like
+        1-D array of grid frequency coordinates. Positive and monotonically increasing.
+    dirs : array-like
+        1-D array of grid direction coordinates. Positive and monotonically increasing.
+        Must cover the directional range [0, 360) degrees (or [0, 2 * numpy.pi) radians).
+    vals : array-like (N, M)
+        Spectrum density values associated with the grid. Should be a 2-D array
+        of shape (N, M), such that ``N=len(freq)`` and ``M=len(dirs)``.
+    freq_hz : bool
+        If frequency is given in 'Hz'. If ``False``, 'rad/s' is assumed.
+    degrees : bool
+        If direction is given in 'degrees'. If ``False``, 'radians' is assumed.
+    clockwise : bool
+        If positive directions are defined to be 'clockwise' (``True``) or 'counterclockwise'
+        (``False``). Clockwise means that the directions follow the right-hand rule
+        with an axis pointing downwards.
+    waves_coming_from : bool
+        If waves are 'coming from' the given directions. If ``False``, 'going towards'
+        convention is assumed.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if np.any(np.iscomplex(self._vals)):
+            raise ValueError("Spectrum values can not be complex.")
+        elif np.any(self._vals < 0.0):
+            raise ValueError("Spectrum values must be positive.")
+
     def __repr__(self):
         return "WaveSpectrum"
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2737,14 +2737,22 @@ class Test_DirectionalSpectrum:
         with pytest.raises(ValueError):
             DirectionalSpectrum(freq, dirs, values, freq_hz=True, degrees=True)
 
-    def test__init__raises_vals_neg(self):
+    def test__init__vals_neg_ok(self):
         freq = np.arange(0.05, 1, 0.1)
         dirs = np.arange(5.0, 360.0, 10.0)
         vals = np.random.random(size=(len(freq), len(dirs)))
         vals[0, 1] *= -1
 
-        with pytest.raises(ValueError):
-            DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+        _ = DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+    def test__init__vals_complex_ok(self):
+        freq = np.arange(0.05, 1, 0.1)
+        dirs = np.arange(5.0, 360.0, 10.0)
+        vals = np.random.random(size=(len(freq), len(dirs)))
+        vals = vals + 1j * vals
+
+        _ = DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
 
     def test__init__raises_freq_neg(self):
         freq = np.arange(-0.05, 1, 0.1)
@@ -3288,6 +3296,21 @@ class Test_DirectionalSpectrum:
 
         assert m_out == pytest.approx(m_expect)
 
+    def test_moment_m0_hz_complex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        yp = np.linspace(f0, f1, 20)
+        xp = np.arange(5, 360, 10)
+        vp = np.ones((len(yp), len(xp))) + 1j * np.ones((len(yp), len(xp)))
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        m_out = spectrum.moment(0, freq_hz=True)
+
+        m_expect = (0.0 - 360.0) * (f0 - f1) + 1j * (0.0 - 360.0) * (f0 - f1)
+
+        assert m_out == pytest.approx(m_expect)
+
     def test_moment_m0_rads(self):
         f0 = 0.0
         f1 = 2.0
@@ -3300,6 +3323,21 @@ class Test_DirectionalSpectrum:
         m_out = spectrum.moment(0, freq_hz=False)
 
         m_expect = (0.0 - 360.0) * (f0 - f1)
+
+        assert m_out == pytest.approx(m_expect)
+
+    def test_moment_m0_rads_complex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        yp = np.linspace(f0, f1, 20)
+        xp = np.arange(5, 360, 10)
+        vp = np.ones((len(yp), len(xp))) + 1j * np.ones((len(yp), len(xp)))
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        m_out = spectrum.moment(0, freq_hz=False)
+
+        m_expect = (0.0 - 360.0) * (f0 - f1) + 1j * (0.0 - 360.0) * (f0 - f1)
 
         assert m_out == pytest.approx(m_expect)
 
@@ -3318,6 +3356,21 @@ class Test_DirectionalSpectrum:
 
         assert m_out == pytest.approx(m_expect)
 
+    def test_moment_m1_hz_comlex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        yp = np.linspace(f0, f1, 20)
+        xp = np.arange(5, 360, 10)
+        vp = np.ones((len(yp), len(xp))) + 1j * np.ones((len(yp), len(xp)))
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        m_out = spectrum.moment(1, freq_hz=True)
+
+        m_expect = (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) + 1j * (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2)
+
+        assert m_out == pytest.approx(m_expect)
+
     def test_moment_m1_rads(self):
         f0 = 0.0
         f1 = 2.0
@@ -3330,6 +3383,21 @@ class Test_DirectionalSpectrum:
         m_out = spectrum.moment(1, freq_hz=False)
 
         m_expect = (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) * (2.0 * np.pi)
+
+        assert m_out == pytest.approx(m_expect)
+
+    def test_moment_m1_rads_complex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        yp = np.linspace(f0, f1, 20)
+        xp = np.arange(5, 360, 10)
+        vp = np.ones((len(yp), len(xp))) + 1j * np.ones((len(yp), len(xp)))
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        m_out = spectrum.moment(1, freq_hz=False)
+
+        m_expect = (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) * (2.0 * np.pi) + 1j * (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) * (2.0 * np.pi)
 
         assert m_out == pytest.approx(m_expect)
 
@@ -3349,6 +3417,22 @@ class Test_DirectionalSpectrum:
         # not exactly same due to error in trapezoid for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)
 
+    def test_moment_m2_hz_complex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        yp = np.linspace(f0, f1, 20)
+        xp = np.arange(5, 360, 10)
+        vp = np.ones((len(yp), len(xp))) + 1j * np.ones((len(yp), len(xp)))
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        m_out = spectrum.moment(2, freq_hz=True)
+
+        m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) + 1j*(1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3)
+
+        # not exactly same due to error in trapezoid for higher order functions
+        assert m_out == pytest.approx(m_expect, rel=0.1)
+
     def test_moment_m2_rads(self):
         f0 = 0.0
         f1 = 2.0
@@ -3361,6 +3445,22 @@ class Test_DirectionalSpectrum:
         m_out = spectrum.moment(2, freq_hz=False)
 
         m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2
+
+        # not exactly same due to error in trapezoid for higher order functions
+        assert m_out == pytest.approx(m_expect, rel=0.1)
+
+    def test_moment_m2_rads_complex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        yp = np.linspace(f0, f1, 20)
+        xp = np.arange(5, 360, 10)
+        vp = np.ones((len(yp), len(xp))) + 1j * np.ones((len(yp), len(xp)))
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        m_out = spectrum.moment(2, freq_hz=False)
+
+        m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2 + 1j * (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2
 
         # not exactly same due to error in trapezoid for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)
@@ -3382,6 +3482,30 @@ class Test_DirectionalSpectrum:
         tz_expect = np.sqrt(m0 / m2)
 
         assert tz_out == pytest.approx(tz_expect, rel=0.1)
+
+    def test_tz_raises_complex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = np.ones((len(freq), len(dirs))) + 1j * np.ones((len(freq), len(dirs)))
+        spectrum = DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+        with pytest.raises(ValueError):
+            _ = spectrum.tz
+
+    def test_tz_raises_neg(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = -np.ones((len(freq), len(dirs)))
+        spectrum = DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+        with pytest.raises(ValueError):
+            _ = spectrum.tz
 
     def test_from_grid(self):
         freq = np.linspace(0, 1.0, 10)
@@ -3439,18 +3563,6 @@ class Test_DirectionalSpectrum:
         assert spectrum._freq_hz == grid._freq_hz
         assert spectrum._degrees == grid._degrees
 
-    def test_conjugate_raises(self, directional_spectrum):
-        with pytest.raises(AttributeError):
-            directional_spectrum.conjugate()
-
-    def test_real_raises(self, directional_spectrum):
-        with pytest.raises(AttributeError):
-            directional_spectrum.real
-
-    def test_imag_raises(self, directional_spectrum):
-        with pytest.raises(AttributeError):
-            directional_spectrum.imag
-
     def test_extreme_float(self):
         f0 = 0.0
         f1 = 2.0
@@ -3470,6 +3582,34 @@ class Test_DirectionalSpectrum:
         extreme_expect = sigma * np.sqrt(2.0 * np.log((T / tz) / np.log(1.0 / q)))
 
         assert extreme_out == pytest.approx(extreme_expect)
+
+    def test_extreme_raises_complex(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = np.ones((len(freq), len(dirs))) + 1j*np.ones((len(freq), len(dirs)))
+        spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+        T = 360 * 24 * 60.0**2
+        q = 0.99
+        with pytest.raises(ValueError):
+            _ = spectrum.extreme(T, q=q)
+
+    def test_extreme_raises_neg(self):
+        f0 = 0.0
+        f1 = 2.0
+
+        freq = np.linspace(f0, f1, 20)
+        dirs = np.arange(5, 360, 10)
+        vals = -np.ones((len(freq), len(dirs)))
+        spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+        T = 360 * 24 * 60.0**2
+        q = 0.99
+        with pytest.raises(ValueError):
+            _ = spectrum.extreme(T, q=q)
 
     def test_extreme_list(self):
         f0 = 0.0
@@ -3595,8 +3735,38 @@ class Test_WaveSpectrum:
         assert spectrum._freq_hz == grid._freq_hz
         assert spectrum._degrees == grid._degrees
 
+    def test__init__raises_vals_neg(self):
+        freq = np.arange(0.05, 1, 0.1)
+        dirs = np.arange(5.0, 360.0, 10.0)
+        vals = np.random.random(size=(len(freq), len(dirs)))
+        vals[0, 1] *= -1
+
+        with pytest.raises(ValueError):
+            WaveSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
+    def test__init__raises_vals_complex(self):
+        freq = np.arange(0.05, 1, 0.1)
+        dirs = np.arange(5.0, 360.0, 10.0)
+        vals = np.random.random(size=(len(freq), len(dirs)))
+        vals = vals + 1j*vals
+
+        with pytest.raises(ValueError):
+            WaveSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
+
     def test__repr__(self, wave):
         assert str(wave) == "WaveSpectrum"
+
+    def test_conjugate_raises(self, wave):
+        with pytest.raises(AttributeError):
+            wave.conjugate()
+
+    def test_real_raises(self, wave):
+        with pytest.raises(AttributeError):
+            wave.real
+
+    def test_imag_raises(self, wave):
+        with pytest.raises(AttributeError):
+            wave.imag
 
     def test_hs(self):
         f0 = 0.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2753,7 +2753,6 @@ class Test_DirectionalSpectrum:
 
         _ = DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
-
     def test__init__raises_freq_neg(self):
         freq = np.arange(-0.05, 1, 0.1)
         dirs = np.arange(5.0, 360.0, 10.0)
@@ -3367,7 +3366,9 @@ class Test_DirectionalSpectrum:
 
         m_out = spectrum.moment(1, freq_hz=True)
 
-        m_expect = (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) + 1j * (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2)
+        m_expect = (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) + 1j * (
+            1.0 / 2.0
+        ) * (0.0 - 360.0) * (f0**2 - f1**2)
 
         assert m_out == pytest.approx(m_expect)
 
@@ -3397,7 +3398,9 @@ class Test_DirectionalSpectrum:
 
         m_out = spectrum.moment(1, freq_hz=False)
 
-        m_expect = (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) * (2.0 * np.pi) + 1j * (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) * (2.0 * np.pi)
+        m_expect = (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) * (
+            2.0 * np.pi
+        ) + 1j * (1.0 / 2.0) * (0.0 - 360.0) * (f0**2 - f1**2) * (2.0 * np.pi)
 
         assert m_out == pytest.approx(m_expect)
 
@@ -3428,7 +3431,9 @@ class Test_DirectionalSpectrum:
 
         m_out = spectrum.moment(2, freq_hz=True)
 
-        m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) + 1j*(1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3)
+        m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) + 1j * (
+            1.0 / 3.0
+        ) * (0.0 - 360.0) * (f0**3 - f1**3)
 
         # not exactly same due to error in trapezoid for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)
@@ -3460,7 +3465,11 @@ class Test_DirectionalSpectrum:
 
         m_out = spectrum.moment(2, freq_hz=False)
 
-        m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2 + 1j * (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (2.0 * np.pi) ** 2
+        m_expect = (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (
+            2.0 * np.pi
+        ) ** 2 + 1j * (1.0 / 3.0) * (0.0 - 360.0) * (f0**3 - f1**3) * (
+            2.0 * np.pi
+        ) ** 2
 
         # not exactly same due to error in trapezoid for higher order functions
         assert m_out == pytest.approx(m_expect, rel=0.1)
@@ -3589,7 +3598,7 @@ class Test_DirectionalSpectrum:
 
         freq = np.linspace(f0, f1, 20)
         dirs = np.arange(5, 360, 10)
-        vals = np.ones((len(freq), len(dirs))) + 1j*np.ones((len(freq), len(dirs)))
+        vals = np.ones((len(freq), len(dirs))) + 1j * np.ones((len(freq), len(dirs)))
         spectrum = wr.DirectionalSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)
 
         T = 360 * 24 * 60.0**2
@@ -3748,7 +3757,7 @@ class Test_WaveSpectrum:
         freq = np.arange(0.05, 1, 0.1)
         dirs = np.arange(5.0, 360.0, 10.0)
         vals = np.random.random(size=(len(freq), len(dirs)))
-        vals = vals + 1j*vals
+        vals = vals + 1j * vals
 
         with pytest.raises(ValueError):
             WaveSpectrum(freq, dirs, vals, freq_hz=True, degrees=True)


### PR DESCRIPTION
### This PR is related to user story

## Description
Extend `DirectionalSpectrum` to allow negative and complex-valued spectra. This is useful when calculation cross spectra (for instance, calculating the covariance of heave and pitch).

The negative and complex checks are moved up to `WaveSpectrum`. `tz` and `extreme` methods raise ValueError if spectrum is not positive real-valued. 

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
