### PR TITLE
Revert (refactor out) introduction of BinGrid

### DIFF
--- a/src/waveresponse/__init__.py
+++ b/src/waveresponse/__init__.py
@@ -1,6 +1,6 @@
 from ._core import (
     RAO,
-    BinGrid,
+    # BinGrid,
     CosineFullSpreading,
     CosineHalfSpreading,
     DirectionalBinSpectrum,
@@ -40,7 +40,7 @@ __all__ = [
     "DirectionalSpectrum",
     "DirectionalBinSpectrum",
     "Grid",
-    "BinGrid",
+    # "BinGrid",
     "JONSWAP",
     "ModifiedPiersonMoskowitz",
     "OchiHubble",

--- a/src/waveresponse/__init__.py
+++ b/src/waveresponse/__init__.py
@@ -1,6 +1,5 @@
 from ._core import (
     RAO,
-    # BinGrid,
     CosineFullSpreading,
     CosineHalfSpreading,
     DirectionalBinSpectrum,
@@ -40,7 +39,6 @@ __all__ = [
     "DirectionalSpectrum",
     "DirectionalBinSpectrum",
     "Grid",
-    # "BinGrid",
     "JONSWAP",
     "ModifiedPiersonMoskowitz",
     "OchiHubble",

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -146,6 +146,7 @@ class _GridInterpolator:
     """
     Interpolation function based on ``scipy.interpolate.RegularGridInterpolator``.
     """
+
     def __init__(self, freq, dirs, vals, complex_convert="rectangular", **kwargs):
         xp = np.concatenate((dirs[-1:] - 2 * np.pi, dirs, dirs[:1] + 2.0 * np.pi))
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1654,12 +1654,15 @@ class DirectionalSpectrum(_SpectrumMixin, Grid):
         dirs_bin[0::2] = dirs_tmp[:-1] + np.diff(dirs_tmp) / 2.0  # bin boundaries
         dirs_bin[1::2] = self._dirs  # bin centers
 
-        interp_fun = self._interpolate_function(
-            complex_convert=complex_convert, method="linear", bounds_error=True
+        interp_fun = _GridInterpolator(
+            self._freq,
+            self._dirs,
+            self._vals,
+            complex_convert=complex_convert,
+            method="linear",
+            bounds_error=True
         )
-
-        dirsnew, freqnew = np.meshgrid(dirs_bin, self._freq, indexing="ij", sparse=True)
-        vals_tmp = interp_fun((dirsnew, freqnew)).T
+        vals_tmp = interp_fun(self._freq, dirs_bin)
 
         vals_binned = np.column_stack(
             [

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1938,7 +1938,7 @@ class DirectionalBinSpectrum(_SpectrumMixin, Grid):
         return freq, dirs, vals
 
     def interpolate(self, *args, **kwargs):
-        raise NotImplementedError("Use `.reshape` instead.")
+        raise AttributeError("Use `.reshape` instead.")
 
     def reshape(
         self,

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1660,7 +1660,7 @@ class DirectionalSpectrum(_SpectrumMixin, Grid):
             self._vals,
             complex_convert=complex_convert,
             method="linear",
-            bounds_error=True
+            bounds_error=True,
         )
         vals_tmp = interp_fun(self._freq, dirs_bin)
 

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -143,10 +143,10 @@ def _sort(dirs, vals):
 
 
 class _GridInterpolator:
+    """
+    Interpolation function based on ``scipy.interpolate.RegularGridInterpolator``.
+    """
     def __init__(self, freq, dirs, vals, complex_convert="rectangular", **kwargs):
-        """
-        Interpolation function based on ``scipy.interpolate.RegularGridInterpolator``.
-        """
         xp = np.concatenate((dirs[-1:] - 2 * np.pi, dirs, dirs[:1] + 2.0 * np.pi))
 
         yp = freq

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1871,10 +1871,7 @@ class DirectionalBinSpectrum(_SpectrumMixin, Grid):
 
         return freq, dirs, vals
 
-    def interpolate(
-        self,
-        *args, **kwargs
-    ):
+    def interpolate(self, *args, **kwargs):
         raise NotImplementedError("Use `.reshape` instead.")
 
     def reshape(

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -142,7 +142,7 @@ def _sort(dirs, vals):
     return dirs[sorted_args], vals[:, sorted_args]
 
 
-class _GridInterpolate:
+class _GridInterpolator:
     def __init__(self, freq, dirs, vals, complex_convert="rectangular", **kwargs):
         """
         Interpolation function based on ``scipy.interpolate.RegularGridInterpolator``.
@@ -763,7 +763,7 @@ class Grid:
         self._check_freq(freq)
         self._check_dirs(dirs)
 
-        interp_fun = _GridInterpolate(
+        interp_fun = _GridInterpolator(
             self._freq,
             self._dirs,
             self._vals,
@@ -836,7 +836,7 @@ class Grid:
         self._check_freq(freq_new)
         self._check_dirs(dirs_new)
 
-        interp_fun = _GridInterpolate(
+        interp_fun = _GridInterpolator(
             self._freq,
             self._dirs,
             self._vals,
@@ -1074,7 +1074,7 @@ class RAO(Grid):
         self._check_freq(freq_new)
         self._check_dirs(dirs_new)
 
-        interp_fun = _GridInterpolate(
+        interp_fun = _GridInterpolator(
             freq_new,
             dirs_new,
             self._vals,
@@ -1732,7 +1732,7 @@ class DirectionalSpectrum(_SpectrumMixin, Grid):
         self._check_freq(freq_new)
         self._check_dirs(dirs_new)
 
-        interp_fun = _GridInterpolate(
+        interp_fun = _GridInterpolator(
             self._freq,
             self._dirs,
             self._vals,
@@ -1920,7 +1920,7 @@ class DirectionalBinSpectrum(_SpectrumMixin, Grid):
 
         self._check_freq(freq_new)
 
-        interp_fun = _GridInterpolate(
+        interp_fun = _GridInterpolator(
             self._freq,
             self._dirs,
             self._vals,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,9 +9,8 @@ from scipy.integrate import quad
 from scipy.interpolate import RegularGridInterpolator as RGI
 
 import waveresponse as wr
-from waveresponse import (
+from waveresponse import (  # BinGrid,
     RAO,
-    # BinGrid,
     CosineFullSpreading,
     CosineHalfSpreading,
     DirectionalBinSpectrum,
@@ -745,12 +744,8 @@ class Test__GridInterpolator:
         x = np.linspace(5.0, 15.0, 10)
         vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
 
-        interp_fun = _GridInterpolator(
-            yp * 2.*np.pi,
-            np.radians(xp),
-            vp
-        )
-        vals_out = interp_fun(y * 2. * np.pi, np.radians(x))
+        interp_fun = _GridInterpolator(yp * 2.0 * np.pi, np.radians(xp), vp)
+        vals_out = interp_fun(y * 2.0 * np.pi, np.radians(x))
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
     def test_interpolate_single_coordinate(self):
@@ -761,12 +756,8 @@ class Test__GridInterpolator:
         xp = np.linspace(0.0, 359.0, 10)
         vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
 
-        interp_fun = _GridInterpolator(
-            yp * 2.*np.pi,
-            np.radians(xp),
-            vp
-        )
-        vals_out = interp_fun(1.8 * 2. * np.pi, np.radians(12.1))
+        interp_fun = _GridInterpolator(yp * 2.0 * np.pi, np.radians(xp), vp)
+        vals_out = interp_fun(1.8 * 2.0 * np.pi, np.radians(12.1))
         vals_expect = np.array(a * 12.1 + b * 1.8)
 
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
@@ -782,13 +773,13 @@ class Test__GridInterpolator:
             ]
         )
         interp_fun = _GridInterpolator(
-            freq * 2.*np.pi,
+            freq * 2.0 * np.pi,
             np.radians(dirs),
             vals,
             fill_value=0.0,
             bounds_error=False,
         )
-        vals_out = interp_fun(np.array([10, 20]) * 2. * np.pi, np.radians([0, 90]))
+        vals_out = interp_fun(np.array([10, 20]) * 2.0 * np.pi, np.radians([0, 90]))
 
         vals_expect = np.array(
             [
@@ -810,13 +801,13 @@ class Test__GridInterpolator:
             ]
         )
         interp_fun = _GridInterpolator(
-            freq * 2.*np.pi,
+            freq * 2.0 * np.pi,
             np.radians(dirs),
             vals,
             fill_value=None,
             bounds_error=False,
         )
-        vals_out = interp_fun(np.array([10, 20]) * 2. * np.pi, np.radians([0, 90]))
+        vals_out = interp_fun(np.array([10, 20]) * 2.0 * np.pi, np.radians([0, 90]))
 
         vals_expect = np.array(
             [
@@ -850,12 +841,9 @@ class Test__GridInterpolator:
         vals_expect = vals_real_expect + 1j * vals_imag_expect
 
         interp_fun = _GridInterpolator(
-            yp * 2.*np.pi,
-            np.radians(xp),
-            vp,
-            complex_convert="rectangular"
+            yp * 2.0 * np.pi, np.radians(xp), vp, complex_convert="rectangular"
         )
-        vals_out = interp_fun(y * 2. * np.pi, np.radians(x))
+        vals_out = interp_fun(y * 2.0 * np.pi, np.radians(x))
 
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
@@ -889,12 +877,9 @@ class Test__GridInterpolator:
         )
 
         interp_fun = _GridInterpolator(
-            yp * 2.*np.pi,
-            np.radians(xp),
-            vp,
-            complex_convert="polar"
+            yp * 2.0 * np.pi, np.radians(xp), vp, complex_convert="polar"
         )
-        vals_out = interp_fun(y * 2. * np.pi, np.radians(x))
+        vals_out = interp_fun(y * 2.0 * np.pi, np.radians(x))
 
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
@@ -903,19 +888,17 @@ class Test__GridInterpolator:
         dirs = np.linspace(0, 360.0, 15, endpoint=False)
         vals = np.zeros((10, 15))
         interp_fun = _GridInterpolator(
-            freq * 2.*np.pi,
+            freq * 2.0 * np.pi,
             np.radians(dirs),
             vals,
             bounds_error=True,
         )
 
         with pytest.raises(ValueError):
-            interp_fun(np.array([0, 0.5]) * 2. * np.pi, np.radians([0, 1, 2, 400]))
+            interp_fun(np.array([0, 0.5]) * 2.0 * np.pi, np.radians([0, 1, 2, 400]))
 
         with pytest.raises(ValueError):
-            interp_fun(np.array([0, 2.]) * 2. * np.pi, np.radians([0, 1, 2, 100]))
-
-
+            interp_fun(np.array([0, 2.0]) * 2.0 * np.pi, np.radians([0, 1, 2, 100]))
 
 
 class Test_Grid:
@@ -1571,9 +1554,7 @@ class Test_Grid:
         dirs_in = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
         config_org = {"clockwise": False, "waves_coming_from": True}
         config_new = {"clockwise": True, "waves_coming_from": False}
-        dirs_out = Grid._convert_dirs(
-            dirs_in, config_new, config_org, degrees=False
-        )
+        dirs_out = Grid._convert_dirs(dirs_in, config_new, config_org, degrees=False)
 
         dirs_expect = np.array([np.pi, 3.0 * np.pi / 4, np.pi / 2, np.pi / 4, 0])
 
@@ -1583,9 +1564,7 @@ class Test_Grid:
         dirs_in = np.array([0, 45.0, 90.0, 135.0, 180.0])
         config_org = {"clockwise": False, "waves_coming_from": True}
         config_new = {"clockwise": True, "waves_coming_from": False}
-        dirs_out = Grid._convert_dirs(
-            dirs_in, config_new, config_org, degrees=True
-        )
+        dirs_out = Grid._convert_dirs(dirs_in, config_new, config_org, degrees=True)
 
         dirs_expect = np.array([180.0, 135.0, 90.0, 45.0, 0])
 
@@ -1927,9 +1906,7 @@ class Test_Grid:
         np.testing.assert_array_almost_equal(grid_scaled._vals, grid._vals * 2)
 
         grid_scaled = grid * (1 + 1j)
-        np.testing.assert_array_almost_equal(
-            grid_scaled._vals, grid._vals * (1 + 1j)
-        )
+        np.testing.assert_array_almost_equal(grid_scaled._vals, grid._vals * (1 + 1j))
 
     def test__rmul__numeric(self, grid):
         grid_scaled = 2.0 * grid
@@ -1999,9 +1976,7 @@ class Test_Grid:
         out = grid + grid
 
         assert isinstance(out, Grid)
-        np.testing.assert_array_almost_equal(
-            out._vals, grid._vals + grid._vals
-        )
+        np.testing.assert_array_almost_equal(out._vals, grid._vals + grid._vals)
 
     def test__add__raises_type(self, grid, rao):
         with pytest.raises(TypeError):
@@ -2010,9 +1985,7 @@ class Test_Grid:
     @patch("waveresponse._core._check_is_similar")
     def test__add__check_is_similar(self, mock_check_is_similar, grid):
         grid + grid
-        mock_check_is_similar.assert_called_once_with(
-            grid, grid, exact_type=True
-        )
+        mock_check_is_similar.assert_called_once_with(grid, grid, exact_type=True)
 
     def test__add__numeric(self, grid):
         grid_added = grid + 2.0
@@ -2025,9 +1998,7 @@ class Test_Grid:
         np.testing.assert_array_almost_equal(grid_added._vals, grid._vals + 2)
 
         grid_added = grid + (1 + 1j)
-        np.testing.assert_array_almost_equal(
-            grid_added._vals, grid._vals + (1 + 1j)
-        )
+        np.testing.assert_array_almost_equal(grid_added._vals, grid._vals + (1 + 1j))
 
     def test__radd__numeric(self, grid):
         grid_added = 2.0 + grid
@@ -2037,16 +2008,12 @@ class Test_Grid:
         out = grid - grid
 
         assert isinstance(out, Grid)
-        np.testing.assert_array_almost_equal(
-            out._vals, grid._vals - grid._vals
-        )
+        np.testing.assert_array_almost_equal(out._vals, grid._vals - grid._vals)
 
     @patch("waveresponse._core._check_is_similar")
     def test__sub__check_is_similar(self, mock_check_is_similar, grid):
         grid - grid
-        mock_check_is_similar.assert_called_once_with(
-            grid, grid, exact_type=True
-        )
+        mock_check_is_similar.assert_called_once_with(grid, grid, exact_type=True)
 
     def test__sub__raises_type(self, grid, rao):
         with pytest.raises(TypeError):
@@ -2054,14 +2021,10 @@ class Test_Grid:
 
     def test__sub__numeric(self, grid):
         grid_subtracted = grid - 2.0
-        np.testing.assert_array_almost_equal(
-            grid_subtracted._vals, grid._vals - 2.0
-        )
+        np.testing.assert_array_almost_equal(grid_subtracted._vals, grid._vals - 2.0)
 
         grid_subtracted = grid - 0.0
-        np.testing.assert_array_almost_equal(
-            grid_subtracted._vals, grid._vals - 0.0
-        )
+        np.testing.assert_array_almost_equal(grid_subtracted._vals, grid._vals - 0.0)
 
         grid_subtracted = grid - 2
         np.testing.assert_array_almost_equal(grid_subtracted._vals, grid._vals - 2)
@@ -2073,18 +2036,14 @@ class Test_Grid:
 
     def test__rsub__numeric(self, grid):
         grid_subtracted = 2.0 - grid
-        np.testing.assert_array_almost_equal(
-            grid_subtracted._vals, grid._vals - 2.0
-        )
+        np.testing.assert_array_almost_equal(grid_subtracted._vals, grid._vals - 2.0)
 
     def test_conjugate(self, grid):
         grid_conj = grid.conjugate()
 
         np.testing.assert_array_almost_equal(grid_conj._freq, grid._freq)
         np.testing.assert_array_almost_equal(grid_conj._dirs, grid._dirs)
-        np.testing.assert_array_almost_equal(
-            grid_conj._vals, grid._vals.conjugate()
-        )
+        np.testing.assert_array_almost_equal(grid_conj._vals, grid._vals.conjugate())
 
     def test_real(self):
         freq_in = np.array([1, 2, 3])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5114,7 +5114,7 @@ class Test_WaveBinSpectrum:
         dirs_expect = (np.pi / 180.0) * dirs
         vals_expect = vals / (2.0 * np.pi)
 
-        assert isinstance(wave, BinGrid)
+        assert isinstance(wave, Grid)
         assert isinstance(wave, DirectionalBinSpectrum)
         np.testing.assert_array_almost_equal(wave._freq, freq_expect)
         np.testing.assert_array_almost_equal(wave._dirs, dirs_expect)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4329,10 +4329,9 @@ class Test_DirectionalBinSpectrum:
 
         y = np.linspace(0.5, 1.0, 20)
         x = xp
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
 
-        with pytest.raises(NotImplementedError):
-            _ = spectrum.interpolate(y, freq_hz=True)
+        with pytest.raises(AttributeError):
+            _ = spectrum.interpolate(y, x, freq_hz=True, degrees=True)
 
     def test_var(self):
         y0 = 0.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,7 @@ from scipy.interpolate import RegularGridInterpolator as RGI
 import waveresponse as wr
 from waveresponse import (
     RAO,
-    BinGrid,
+    # BinGrid,
     CosineFullSpreading,
     CosineHalfSpreading,
     DirectionalBinSpectrum,
@@ -21,7 +21,7 @@ from waveresponse import (
     calculate_response,
     mirror,
 )
-from waveresponse._core import _BaseGrid, _check_foldable, _check_is_similar
+from waveresponse._core import _check_foldable, _check_is_similar
 
 TEST_PATH = Path(__file__).parent
 
@@ -37,20 +37,20 @@ def freq_dirs():
     return freq, dirs
 
 
-@pytest.fixture
-def base_grid(freq_dirs):
-    freq, dirs = freq_dirs
-    vals = np.random.random((len(freq), len(dirs)))
-    grid = _BaseGrid(
-        freq,
-        dirs,
-        vals,
-        freq_hz=True,
-        degrees=True,
-        clockwise=True,
-        waves_coming_from=True,
-    )
-    return grid
+# @pytest.fixture
+# def base_grid(freq_dirs):
+#     freq, dirs = freq_dirs
+#     vals = np.random.random((len(freq), len(dirs)))
+#     grid = _BaseGrid(
+#         freq,
+#         dirs,
+#         vals,
+#         freq_hz=True,
+#         degrees=True,
+#         clockwise=True,
+#         waves_coming_from=True,
+#     )
+#     return grid
 
 
 @pytest.fixture
@@ -69,20 +69,20 @@ def grid(freq_dirs):
     return grid
 
 
-@pytest.fixture
-def bingrid(freq_dirs):
-    freq, dirs = freq_dirs
-    vals = np.random.random((len(freq), len(dirs)))
-    grid = BinGrid(
-        freq,
-        dirs,
-        vals,
-        freq_hz=True,
-        degrees=True,
-        clockwise=True,
-        waves_coming_from=True,
-    )
-    return grid
+# @pytest.fixture
+# def bingrid(freq_dirs):
+#     freq, dirs = freq_dirs
+#     vals = np.random.random((len(freq), len(dirs)))
+#     grid = BinGrid(
+#         freq,
+#         dirs,
+#         vals,
+#         freq_hz=True,
+#         degrees=True,
+#         clockwise=True,
+#         waves_coming_from=True,
+#     )
+#     return grid
 
 
 @pytest.fixture
@@ -764,850 +764,7 @@ class Test__check_foldable:
             _check_foldable(np.array([]), degrees=True, sym_plane="xz")
 
 
-class Test__BaseGrid:
-    def test__init__(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        np.testing.assert_array_almost_equal(grid._freq, 2.0 * np.pi * freq)
-        np.testing.assert_array_almost_equal(grid._dirs, (np.pi / 180.0) * dirs)
-        np.testing.assert_array_almost_equal(grid._vals, vals)
-        assert grid._clockwise is True
-        assert grid._waves_coming_from is True
-        assert grid._freq_hz is True
-        assert grid._degrees is True
-
-    def test__init__2(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 2.0 * np.pi, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=False,
-            degrees=False,
-            clockwise=False,
-            waves_coming_from=False,
-        )
-
-        np.testing.assert_array_almost_equal(grid._freq, freq)
-        np.testing.assert_array_almost_equal(grid._dirs, dirs)
-        np.testing.assert_array_almost_equal(grid._vals, vals)
-        assert grid._clockwise is False
-        assert grid._waves_coming_from is False
-        assert grid._freq_hz is False
-        assert grid._degrees is False
-
-    def test__init__raises_duplicate_freq(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 1, 2])
-            dirs = np.array([0, 1, 2])
-            vals = np.zeros((4, 3))
-            _BaseGrid(freq, dirs, vals)
-
-    def test__init__raises_duplicate_dirs(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 2])
-            dirs = np.array([0, 1, 1, 2])
-            vals = np.zeros((3, 4))
-            _BaseGrid(freq, dirs, vals)
-
-    def test__init__raises_negative_freq(self):
-        with pytest.raises(ValueError):
-            freq = np.array([-1, 1, 2, 3])
-            dirs = np.array([0, 1, 2])
-            vals = np.zeros((4, 3))
-            _BaseGrid(freq, dirs, vals)
-
-    def test__init__raises_negative_dirs(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 2, 3])
-            dirs = np.array([-1, 1, 2])
-            vals = np.zeros((4, 3))
-            Grid(freq, dirs, vals)
-
-    def test__init__raises_freq_not_increasing(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 2, 1])
-            dirs = np.array([0, 1, 2])
-            vals = np.zeros((4, 3))
-            _BaseGrid(freq, dirs, vals)
-
-    def test__init__raises_dirs_not_increasing(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 2])
-            dirs = np.array([0, 1, 2, 1])
-            vals = np.zeros((3, 4))
-            _BaseGrid(freq, dirs, vals)
-
-    def test__init__raises_dirs_2pi(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 2])
-            dirs = np.array([0, 1, 2, 2.0 * np.pi])
-            vals = np.zeros((3, 4))
-            _BaseGrid(freq, dirs, vals, degrees=False)
-
-    def test__init__raises_dirs_greater_than_2pi(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 2])
-            dirs = np.array([0, 1, 2, 3.0 * np.pi])
-            vals = np.zeros((3, 4))
-            _BaseGrid(freq, dirs, vals, degrees=False)
-
-    def test__init__raises_freq_not_1d(self):
-        with pytest.raises(ValueError, match="`freq` must be 1 dimensional."):
-            freq = np.array([[0, 1], [2, 3]])
-            dirs = np.array([0.0, 1.0, 1.5, 2.0])
-            vals = np.zeros((4, 4))
-            _BaseGrid(freq, dirs, vals)
-
-    def test__init__raises_dirs_not_1d(self):
-        with pytest.raises(ValueError, match="`dirs` must be 1 dimensional."):
-            freq = np.array([0, 1, 2, 3])
-            dirs = np.array([[0.0, 1.0], [1.5, 2.0]])
-            vals = np.zeros((4, 4))
-            _BaseGrid(freq, dirs, vals)
-
-    def test__init__raises_vals_shape(self):
-        with pytest.raises(ValueError):
-            freq = np.array([0, 1, 2])
-            dirs = np.array([0, 1, 2, 3])
-            vals = np.zeros((3, 10))
-            _BaseGrid(freq, dirs, vals)
-
-    def test_from_grid(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.random.random((10, 15))
-        grid_in = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        grid_out = _BaseGrid.from_grid(grid_in)
-
-        vals_expect = vals.copy()
-
-        assert isinstance(grid_out, _BaseGrid)
-        np.testing.assert_array_almost_equal(grid_out._freq, grid_in._freq)
-        np.testing.assert_array_almost_equal(grid_out._dirs, grid_in._dirs)
-        np.testing.assert_array_almost_equal(grid_out._vals, vals_expect)
-        assert grid_out._clockwise == grid_in._clockwise
-        assert grid_out._waves_coming_from == grid_in._waves_coming_from
-        assert grid_out._freq_hz == grid_in._freq_hz
-        assert grid_out._degrees == grid_in._degrees
-
-    def test_freq_None(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        freq_out = grid.freq()
-        np.testing.assert_array_almost_equal(freq_out, freq)
-
-    def test_freq_rads(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        freq_out = grid.freq(freq_hz=False)
-        np.testing.assert_array_almost_equal(freq_out, (2.0 * np.pi) * freq)
-
-    def test_freq_hz(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        freq_out = grid.freq(freq_hz=True)
-        np.testing.assert_array_almost_equal(freq_out, freq)
-
-    def test_dirs_None(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        dirs_out = grid.dirs()
-        np.testing.assert_array_almost_equal(dirs_out, dirs)
-
-    def test_dirs_rad(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        dirs_out = grid.dirs(degrees=False)
-        np.testing.assert_array_almost_equal(dirs_out, (np.pi / 180.0) * dirs)
-
-    def test_dirs_deg(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        dirs_out = grid.dirs(degrees=True)
-        np.testing.assert_array_almost_equal(dirs_out, dirs)
-
-    def test_wave_convention(self, base_grid):
-        convention_expect = {"clockwise": True, "waves_coming_from": True}
-        convention_out = base_grid.wave_convention
-        assert convention_out == convention_expect
-
-    def test__convert_dirs_radians(self):
-        dirs_in = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
-        config_org = {"clockwise": False, "waves_coming_from": True}
-        config_new = {"clockwise": True, "waves_coming_from": False}
-        dirs_out = _BaseGrid._convert_dirs(
-            dirs_in, config_new, config_org, degrees=False
-        )
-
-        dirs_expect = np.array([np.pi, 3.0 * np.pi / 4, np.pi / 2, np.pi / 4, 0])
-
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-
-    def test__convert_dirs_degrees(self):
-        dirs_in = np.array([0, 45.0, 90.0, 135.0, 180.0])
-        config_org = {"clockwise": False, "waves_coming_from": True}
-        config_new = {"clockwise": True, "waves_coming_from": False}
-        dirs_out = _BaseGrid._convert_dirs(
-            dirs_in, config_new, config_org, degrees=True
-        )
-
-        dirs_expect = np.array([180.0, 135.0, 90.0, 45.0, 0])
-
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-
-    def test__convert(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        freq_in = np.array([0.0, 0.5, 1.0])
-        dirs_in = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
-        vals_in = np.array(
-            [
-                [1.0, 2.0, 3.0, 4.0, 5.0],
-                [1.0, 2.0, 3.0, 4.0, 5.0],
-            ]
-        )
-        config_org = {"clockwise": False, "waves_coming_from": True}
-        config_new = {"clockwise": True, "waves_coming_from": False}
-        freq_out, dirs_out, vals_out = grid._convert(
-            freq_in, dirs_in, vals_in, config_new, config_org
-        )
-
-        freq_expect = freq_in
-        dirs_expect = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
-        vals_expect = np.array(
-            [
-                [5.0, 4.0, 3.0, 2.0, 1.0],
-                [5.0, 4.0, 3.0, 2.0, 1.0],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(freq_out, freq_expect)
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_set_wave_convention(self):
-        freq_in = np.array([0.0, 0.5, 1.0])
-        dirs_in = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
-        vals_in = np.array(
-            [
-                [1.0, 2.0, 3.0, 4.0, 5.0],
-                [1.0, 2.0, 3.0, 4.0, 5.0],
-                [1.0, 2.0, 3.0, 4.0, 5.0],
-            ]
-        )
-        grid = _BaseGrid(
-            freq_in,
-            dirs_in,
-            vals_in,
-            freq_hz=True,
-            degrees=False,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        grid.set_wave_convention(clockwise=True, waves_coming_from=False)
-
-        freq_expect = (2.0 * np.pi) * freq_in
-        dirs_expect = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
-        vals_expect = np.array(
-            [
-                [5.0, 4.0, 3.0, 2.0, 1.0],
-                [5.0, 4.0, 3.0, 2.0, 1.0],
-                [5.0, 4.0, 3.0, 2.0, 1.0],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(grid._freq, freq_expect)
-        np.testing.assert_array_almost_equal(grid._dirs, dirs_expect)
-        np.testing.assert_array_almost_equal(grid._vals, vals_expect)
-        assert grid._clockwise is True
-        assert grid._waves_coming_from is False
-
-    def test_copy(self, base_grid):
-        grid_copy = base_grid.copy()
-        assert base_grid is base_grid
-        assert grid_copy is not base_grid
-        np.testing.assert_array_almost_equal(grid_copy._freq, base_grid._freq)
-        np.testing.assert_array_almost_equal(grid_copy._dirs, base_grid._dirs)
-        np.testing.assert_array_almost_equal(grid_copy._vals, base_grid._vals)
-        assert grid_copy._clockwise == base_grid._clockwise
-        assert grid_copy._waves_coming_from == base_grid._waves_coming_from
-
-    def test_rotate_deg(self):
-        freq = np.array([0, 1])
-        dirs = np.array([0, 90, 180])
-        vals = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        grid_rot = grid.rotate(45, degrees=True)
-
-        freq_expect = (2.0 * np.pi) * np.array([0, 1])
-        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 315])
-        vals_expect = np.array(
-            [
-                [2, 3, 1],
-                [2, 3, 1],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
-        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
-        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
-
-    def test_rotate_deg_neg(self):
-        freq = np.array([0, 1])
-        dirs = np.array([0, 90, 180])
-        vals = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        grid_rot = grid.rotate(-45, degrees=True)
-
-        freq_expect = (2.0 * np.pi) * np.array([0, 1])
-        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 225])
-        vals_expect = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
-        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
-        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
-
-    def test_rotate_rad(self):
-        freq = np.array([0, 1])
-        dirs = np.array([0, 90, 180])
-        vals = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        grid_rot = grid.rotate(np.pi / 4, degrees=False)
-
-        freq_expect = (2.0 * np.pi) * np.array([0, 1])
-        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 315])
-        vals_expect = np.array(
-            [
-                [2, 3, 1],
-                [2, 3, 1],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
-        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
-        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
-
-    def test_rotate_rad_neg(self):
-        freq = np.array([0, 1])
-        dirs = np.array([0, 90, 180])
-        vals = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        grid_rot = grid.rotate(-np.pi / 4, degrees=False)
-
-        freq_expect = (2.0 * np.pi) * np.array([0, 1])
-        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 225])
-        vals_expect = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
-        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
-        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
-
-    def test_grid(self):
-        freq = np.array([0, 1])
-        dirs = np.array([0, 90, 180])
-        vals = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        freq_out, dirs_out, vals_out = grid.grid(freq_hz=True, degrees=True)
-
-        freq_expect = np.array([0, 1])
-        dirs_expect = np.array([0, 90, 180])
-        vals_expect = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(freq_out, freq_expect)
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test__grid2(self):
-        freq = np.array([0, 1])
-        dirs = np.array([0, 90, 180])
-        vals = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-        grid = _BaseGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
-            degrees=True,
-            clockwise=False,
-            waves_coming_from=True,
-        )
-
-        freq_out, dirs_out, vals_out = grid.grid(freq_hz=False, degrees=False)
-
-        freq_expect = (2.0 * np.pi) * np.array([0, 1])
-        dirs_expect = (np.pi / 180.0) * np.array([0, 90, 180])
-        vals_expect = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-
-        np.testing.assert_array_almost_equal(freq_out, freq_expect)
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test__mul__(self):
-        freq_in = np.array([1, 2, 3])
-        dirs_in = np.array([0, 10, 20, 30])
-        vals_in = np.array(
-            [
-                [1, 2, 3, 4],
-                [1, 2, 3, 4],
-                [1, 2, 3, 4],
-            ]
-        )
-        grid = _BaseGrid(freq_in, dirs_in, vals_in, degrees=True)
-
-        grid_squared = grid * grid
-
-        vals_expect = np.array(
-            [
-                [1, 4, 9, 16],
-                [1, 4, 9, 16],
-                [1, 4, 9, 16],
-            ]
-        )
-
-        assert isinstance(grid_squared, _BaseGrid)
-        assert grid_squared._clockwise == grid._clockwise
-        assert grid_squared._waves_coming_from == grid._waves_coming_from
-        np.testing.assert_array_almost_equal(grid_squared._freq, grid._freq)
-        np.testing.assert_array_almost_equal(grid_squared._dirs, grid._dirs)
-        np.testing.assert_array_almost_equal(grid_squared._vals, vals_expect)
-
-    def test__mul__numeric(self, base_grid):
-        grid_scaled = base_grid * 2.0
-        np.testing.assert_array_almost_equal(grid_scaled._vals, base_grid._vals * 2.0)
-
-        grid_scaled = base_grid * -2.0
-        np.testing.assert_array_almost_equal(grid_scaled._vals, base_grid._vals * -2.0)
-
-        grid_scaled = base_grid * 0.0
-        np.testing.assert_array_almost_equal(grid_scaled._vals, base_grid._vals * 0.0)
-
-        grid_scaled = base_grid * 2
-        np.testing.assert_array_almost_equal(grid_scaled._vals, base_grid._vals * 2)
-
-        grid_scaled = base_grid * (1 + 1j)
-        np.testing.assert_array_almost_equal(
-            grid_scaled._vals, base_grid._vals * (1 + 1j)
-        )
-
-    def test__rmul__numeric(self, base_grid):
-        grid_scaled = 2.0 * base_grid
-        np.testing.assert_array_almost_equal(grid_scaled._vals, base_grid._vals * 2.0)
-
-    def test__mul__raises_array(self, base_grid):
-        with pytest.raises(TypeError):
-            base_grid * base_grid._vals
-
-    def test__mul__raises_type(self, base_grid, rao):
-        with pytest.raises(TypeError):
-            base_grid * rao
-
-    def test__mul__raises_shape(self):
-        freq_in = np.array([1, 2, 3])
-        dirs_in = np.array([0, 10, 20, 30])
-        vals_in = np.array(
-            [
-                [1, 2, 3, 4],
-                [1, 2, 3, 4],
-                [1, 2, 3, 4],
-            ]
-        )
-        grid = _BaseGrid(freq_in, dirs_in, vals_in, degrees=True)
-
-        freq_in2 = np.array([1, 2])
-        dirs_in2 = np.array([0, 10, 20])
-        vals_in2 = np.array(
-            [
-                [1, 2, 3],
-                [1, 2, 3],
-            ]
-        )
-        grid2 = _BaseGrid(freq_in2, dirs_in2, vals_in2, degrees=True)
-
-        with pytest.raises(ValueError):
-            grid * grid2
-
-    def test__mul__raises_freq(self, base_grid):
-        grid2 = base_grid.copy()
-        grid2._freq = 2.0 * grid2._freq
-
-        with pytest.raises(ValueError):
-            base_grid * grid2
-
-    def test__mul__raises_dirs(self, base_grid):
-        grid2 = base_grid.copy()
-        grid2._dirs = 2.0 * grid2._dirs
-
-        with pytest.raises(ValueError):
-            base_grid * grid2
-
-    def test__mul__raises_convention(self, base_grid):
-        base_grid.set_wave_convention(clockwise=False, waves_coming_from=False)
-
-        grid2 = base_grid.copy()
-        grid2.set_wave_convention(clockwise=True, waves_coming_from=False)
-        with pytest.raises(ValueError):
-            base_grid * grid2
-
-        grid3 = base_grid.copy()
-        grid3.set_wave_convention(clockwise=False, waves_coming_from=True)
-        with pytest.raises(ValueError):
-            base_grid * grid3
-
-    def test__add__(self, base_grid):
-        out = base_grid + base_grid
-
-        assert isinstance(out, _BaseGrid)
-        np.testing.assert_array_almost_equal(
-            out._vals, base_grid._vals + base_grid._vals
-        )
-
-    def test__add__raises_type(self, base_grid, rao):
-        with pytest.raises(TypeError):
-            base_grid + rao
-
-    @patch("waveresponse._core._check_is_similar")
-    def test__add__check_is_similar(self, mock_check_is_similar, base_grid):
-        base_grid + base_grid
-        mock_check_is_similar.assert_called_once_with(
-            base_grid, base_grid, exact_type=True
-        )
-
-    def test__add__numeric(self, base_grid):
-        grid_added = base_grid + 2.0
-        np.testing.assert_array_almost_equal(grid_added._vals, base_grid._vals + 2.0)
-
-        grid_added = base_grid + 0.0
-        np.testing.assert_array_almost_equal(grid_added._vals, base_grid._vals + 0.0)
-
-        grid_added = base_grid + 2
-        np.testing.assert_array_almost_equal(grid_added._vals, base_grid._vals + 2)
-
-        grid_added = base_grid + (1 + 1j)
-        np.testing.assert_array_almost_equal(
-            grid_added._vals, base_grid._vals + (1 + 1j)
-        )
-
-    def test__radd__numeric(self, base_grid):
-        grid_added = 2.0 + base_grid
-        np.testing.assert_array_almost_equal(grid_added._vals, base_grid._vals + 2.0)
-
-    def test__sub__(self, base_grid):
-        out = base_grid - base_grid
-
-        assert isinstance(out, _BaseGrid)
-        np.testing.assert_array_almost_equal(
-            out._vals, base_grid._vals - base_grid._vals
-        )
-
-    @patch("waveresponse._core._check_is_similar")
-    def test__sub__check_is_similar(self, mock_check_is_similar, base_grid):
-        base_grid - base_grid
-        mock_check_is_similar.assert_called_once_with(
-            base_grid, base_grid, exact_type=True
-        )
-
-    def test__sub__raises_type(self, base_grid, rao):
-        with pytest.raises(TypeError):
-            base_grid - rao
-
-    def test__sub__numeric(self, base_grid):
-        grid_subtracted = base_grid - 2.0
-        np.testing.assert_array_almost_equal(
-            grid_subtracted._vals, base_grid._vals - 2.0
-        )
-
-        grid_subtracted = base_grid - 0.0
-        np.testing.assert_array_almost_equal(
-            grid_subtracted._vals, base_grid._vals - 0.0
-        )
-
-        grid_subtracted = base_grid - 2
-        np.testing.assert_array_almost_equal(grid_subtracted._vals, base_grid._vals - 2)
-
-        grid_subtracted = base_grid - (1 + 1j)
-        np.testing.assert_array_almost_equal(
-            grid_subtracted._vals, base_grid._vals - (1 + 1j)
-        )
-
-    def test__rsub__numeric(self, base_grid):
-        grid_subtracted = 2.0 - base_grid
-        np.testing.assert_array_almost_equal(
-            grid_subtracted._vals, base_grid._vals - 2.0
-        )
-
-    def test__repr__(self, base_grid):
-        assert str(base_grid) == "_BaseGrid"
-
-    def test_conjugate(self, base_grid):
-        grid_conj = base_grid.conjugate()
-
-        np.testing.assert_array_almost_equal(grid_conj._freq, base_grid._freq)
-        np.testing.assert_array_almost_equal(grid_conj._dirs, base_grid._dirs)
-        np.testing.assert_array_almost_equal(
-            grid_conj._vals, base_grid._vals.conjugate()
-        )
-
-    def test_real(self):
-        freq_in = np.array([1, 2, 3])
-        dirs_in = np.array([0, 10, 20])
-        vals_in = np.array(
-            [
-                [1.0 + 0.0j, 0.0 + 1.0j, -1.0 + 0.0j],
-                [2.0 + 0.0j, 0.0 - 2.0j, -2.0 + 0.0j],
-                [3.0 + 0.0j, 0.0 + 3.0j, -3.0 + 0.0j],
-            ]
-        )
-        grid = _BaseGrid(
-            freq_in,
-            dirs_in,
-            vals_in,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        grid_real = grid.real
-
-        vals_expect = np.array(
-            [
-                [1.0, 0.0, -1.0],
-                [2.0, 0.0, -2.0],
-                [3.0, 0.0, -3.0],
-            ]
-        )
-
-        assert isinstance(grid_real, _BaseGrid)
-        np.testing.assert_array_almost_equal(grid_real._vals, vals_expect)
-
-    def test_imag(self):
-        freq_in = np.array([1, 2, 3])
-        dirs_in = np.array([0, 10, 20])
-        vals_in = np.array(
-            [
-                [1.0 + 0.0j, 0.0 + 1.0j, -1.0 + 0.0j],
-                [2.0 + 0.0j, 0.0 - 2.0j, -2.0 + 0.0j],
-                [3.0 + 0.0j, 0.0 + 3.0j, -3.0 + 0.0j],
-            ]
-        )
-        grid = _BaseGrid(
-            freq_in,
-            dirs_in,
-            vals_in,
-            degrees=True,
-            clockwise=True,
-            waves_coming_from=True,
-        )
-
-        grid_imag = grid.imag
-
-        vals_expect = np.array(
-            [
-                [0.0, 1.0, 0.0],
-                [0.0, -2.0, 0.0],
-                [0.0, 3.0, 0.0],
-            ]
-        )
-
-        assert isinstance(grid_imag, _BaseGrid)
-        np.testing.assert_array_almost_equal(grid_imag._vals, vals_expect)
-
-
-class Test_Grid:
+class Test__Grid:
     def test__init__(self):
         freq = np.linspace(0, 1.0, 10)
         dirs = np.linspace(0, 360.0, 15, endpoint=False)
@@ -1622,7 +779,6 @@ class Test_Grid:
             waves_coming_from=True,
         )
 
-        assert isinstance(grid, _BaseGrid)
         np.testing.assert_array_almost_equal(grid._freq, 2.0 * np.pi * freq)
         np.testing.assert_array_almost_equal(grid._dirs, (np.pi / 180.0) * dirs)
         np.testing.assert_array_almost_equal(grid._vals, vals)
@@ -2024,13 +1180,110 @@ class Test_Grid:
     def test__repr__(self, grid):
         assert str(grid) == "Grid"
 
+    def test__init__2(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 2.0 * np.pi, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=False,
+            degrees=False,
+            clockwise=False,
+            waves_coming_from=False,
+        )
 
-class Test_BinGrid:
-    def test__init__(self):
+        np.testing.assert_array_almost_equal(grid._freq, freq)
+        np.testing.assert_array_almost_equal(grid._dirs, dirs)
+        np.testing.assert_array_almost_equal(grid._vals, vals)
+        assert grid._clockwise is False
+        assert grid._waves_coming_from is False
+        assert grid._freq_hz is False
+        assert grid._degrees is False
+
+    def test__init__raises_duplicate_freq(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 1, 2])
+            dirs = np.array([0, 1, 2])
+            vals = np.zeros((4, 3))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_duplicate_dirs(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 2])
+            dirs = np.array([0, 1, 1, 2])
+            vals = np.zeros((3, 4))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_negative_freq(self):
+        with pytest.raises(ValueError):
+            freq = np.array([-1, 1, 2, 3])
+            dirs = np.array([0, 1, 2])
+            vals = np.zeros((4, 3))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_negative_dirs(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 2, 3])
+            dirs = np.array([-1, 1, 2])
+            vals = np.zeros((4, 3))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_freq_not_increasing(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 2, 1])
+            dirs = np.array([0, 1, 2])
+            vals = np.zeros((4, 3))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_dirs_not_increasing(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 2])
+            dirs = np.array([0, 1, 2, 1])
+            vals = np.zeros((3, 4))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_dirs_2pi(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 2])
+            dirs = np.array([0, 1, 2, 2.0 * np.pi])
+            vals = np.zeros((3, 4))
+            Grid(freq, dirs, vals, degrees=False)
+
+    def test__init__raises_dirs_greater_than_2pi(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 2])
+            dirs = np.array([0, 1, 2, 3.0 * np.pi])
+            vals = np.zeros((3, 4))
+            Grid(freq, dirs, vals, degrees=False)
+
+    def test__init__raises_freq_not_1d(self):
+        with pytest.raises(ValueError, match="`freq` must be 1 dimensional."):
+            freq = np.array([[0, 1], [2, 3]])
+            dirs = np.array([0.0, 1.0, 1.5, 2.0])
+            vals = np.zeros((4, 4))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_dirs_not_1d(self):
+        with pytest.raises(ValueError, match="`dirs` must be 1 dimensional."):
+            freq = np.array([0, 1, 2, 3])
+            dirs = np.array([[0.0, 1.0], [1.5, 2.0]])
+            vals = np.zeros((4, 4))
+            Grid(freq, dirs, vals)
+
+    def test__init__raises_vals_shape(self):
+        with pytest.raises(ValueError):
+            freq = np.array([0, 1, 2])
+            dirs = np.array([0, 1, 2, 3])
+            vals = np.zeros((3, 10))
+            Grid(freq, dirs, vals)
+
+    def test_from_grid(self):
         freq = np.linspace(0, 1.0, 10)
         dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = BinGrid(
+        vals = np.random.random((10, 15))
+        grid_in = Grid(
             freq,
             dirs,
             vals,
@@ -2040,336 +1293,708 @@ class Test_BinGrid:
             waves_coming_from=True,
         )
 
-        assert isinstance(grid, _BaseGrid)
-        np.testing.assert_array_almost_equal(grid._freq, 2.0 * np.pi * freq)
-        np.testing.assert_array_almost_equal(grid._dirs, (np.pi / 180.0) * dirs)
-        np.testing.assert_array_almost_equal(grid._vals, vals)
+        grid_out = Grid.from_grid(grid_in)
+
+        vals_expect = vals.copy()
+
+        assert isinstance(grid_out, Grid)
+        np.testing.assert_array_almost_equal(grid_out._freq, grid_in._freq)
+        np.testing.assert_array_almost_equal(grid_out._dirs, grid_in._dirs)
+        np.testing.assert_array_almost_equal(grid_out._vals, vals_expect)
+        assert grid_out._clockwise == grid_in._clockwise
+        assert grid_out._waves_coming_from == grid_in._waves_coming_from
+        assert grid_out._freq_hz == grid_in._freq_hz
+        assert grid_out._degrees == grid_in._degrees
+
+    def test_freq_None(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 360.0, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=True,
+            waves_coming_from=True,
+        )
+
+        freq_out = grid.freq()
+        np.testing.assert_array_almost_equal(freq_out, freq)
+
+    def test_freq_rads(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 360.0, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=True,
+            waves_coming_from=True,
+        )
+
+        freq_out = grid.freq(freq_hz=False)
+        np.testing.assert_array_almost_equal(freq_out, (2.0 * np.pi) * freq)
+
+    def test_freq_hz(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 360.0, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=True,
+            waves_coming_from=True,
+        )
+
+        freq_out = grid.freq(freq_hz=True)
+        np.testing.assert_array_almost_equal(freq_out, freq)
+
+    def test_dirs_None(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 360.0, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=True,
+            waves_coming_from=True,
+        )
+
+        dirs_out = grid.dirs()
+        np.testing.assert_array_almost_equal(dirs_out, dirs)
+
+    def test_dirs_rad(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 360.0, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=True,
+            waves_coming_from=True,
+        )
+
+        dirs_out = grid.dirs(degrees=False)
+        np.testing.assert_array_almost_equal(dirs_out, (np.pi / 180.0) * dirs)
+
+    def test_dirs_deg(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 360.0, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=True,
+            waves_coming_from=True,
+        )
+
+        dirs_out = grid.dirs(degrees=True)
+        np.testing.assert_array_almost_equal(dirs_out, dirs)
+
+    def test_wave_convention(self, grid):
+        convention_expect = {"clockwise": True, "waves_coming_from": True}
+        convention_out = grid.wave_convention
+        assert convention_out == convention_expect
+
+    def test__convert_dirs_radians(self):
+        dirs_in = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
+        config_org = {"clockwise": False, "waves_coming_from": True}
+        config_new = {"clockwise": True, "waves_coming_from": False}
+        dirs_out = Grid._convert_dirs(
+            dirs_in, config_new, config_org, degrees=False
+        )
+
+        dirs_expect = np.array([np.pi, 3.0 * np.pi / 4, np.pi / 2, np.pi / 4, 0])
+
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+
+    def test__convert_dirs_degrees(self):
+        dirs_in = np.array([0, 45.0, 90.0, 135.0, 180.0])
+        config_org = {"clockwise": False, "waves_coming_from": True}
+        config_new = {"clockwise": True, "waves_coming_from": False}
+        dirs_out = Grid._convert_dirs(
+            dirs_in, config_new, config_org, degrees=True
+        )
+
+        dirs_expect = np.array([180.0, 135.0, 90.0, 45.0, 0])
+
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+
+    def test__convert(self):
+        freq = np.linspace(0, 1.0, 10)
+        dirs = np.linspace(0, 360.0, 15, endpoint=False)
+        vals = np.zeros((10, 15))
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        freq_in = np.array([0.0, 0.5, 1.0])
+        dirs_in = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
+        vals_in = np.array(
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+            ]
+        )
+        config_org = {"clockwise": False, "waves_coming_from": True}
+        config_new = {"clockwise": True, "waves_coming_from": False}
+        freq_out, dirs_out, vals_out = grid._convert(
+            freq_in, dirs_in, vals_in, config_new, config_org
+        )
+
+        freq_expect = freq_in
+        dirs_expect = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
+        vals_expect = np.array(
+            [
+                [5.0, 4.0, 3.0, 2.0, 1.0],
+                [5.0, 4.0, 3.0, 2.0, 1.0],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_set_wave_convention(self):
+        freq_in = np.array([0.0, 0.5, 1.0])
+        dirs_in = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
+        vals_in = np.array(
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+            ]
+        )
+        grid = Grid(
+            freq_in,
+            dirs_in,
+            vals_in,
+            freq_hz=True,
+            degrees=False,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        grid.set_wave_convention(clockwise=True, waves_coming_from=False)
+
+        freq_expect = (2.0 * np.pi) * freq_in
+        dirs_expect = np.array([0, np.pi / 4, np.pi / 2, 3.0 * np.pi / 4, np.pi])
+        vals_expect = np.array(
+            [
+                [5.0, 4.0, 3.0, 2.0, 1.0],
+                [5.0, 4.0, 3.0, 2.0, 1.0],
+                [5.0, 4.0, 3.0, 2.0, 1.0],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(grid._freq, freq_expect)
+        np.testing.assert_array_almost_equal(grid._dirs, dirs_expect)
+        np.testing.assert_array_almost_equal(grid._vals, vals_expect)
         assert grid._clockwise is True
-        assert grid._waves_coming_from is True
-        assert grid._freq_hz is True
-        assert grid._degrees is True
+        assert grid._waves_coming_from is False
 
-    def test_interpolate(self):
-        a = 7
-        b = 6
+    def test_copy(self, grid):
+        grid_copy = grid.copy()
+        assert grid is grid
+        assert grid_copy is not grid
+        np.testing.assert_array_almost_equal(grid_copy._freq, grid._freq)
+        np.testing.assert_array_almost_equal(grid_copy._dirs, grid._dirs)
+        np.testing.assert_array_almost_equal(grid_copy._vals, grid._vals)
+        assert grid_copy._clockwise == grid._clockwise
+        assert grid_copy._waves_coming_from == grid._waves_coming_from
 
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
-        bingrid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        vals_out = bingrid.interpolate(y, freq_hz=True)
-
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_interpolate2(self):
-        a = 7
-        b = 6
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
-        bingrid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        y_ = (2.0 * np.pi) * y
-        vals_out = bingrid.interpolate(y_, freq_hz=False)
-
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_interpolate_single_coordinate(self):
-        a = 7
-        b = 6
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp = vp = np.tile(
-            np.linspace(0.0, 1.0, len(yp), endpoint=False).reshape(-1, 1), (1, len(xp))
-        )
-        bingrid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y_ = (yp[4] + yp[5]) / 2
-        vals_out = bingrid.interpolate(y_, freq_hz=True)
-
-        vals_expect = ((vp[4] + vp[5]) / 2).reshape(1, -1)
-
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_interpolate_fill_value(self):
-        freq = np.array([0, 1, 2])
-        dirs = np.array([0, 90, 180, 270])
+    def test_rotate_deg(self):
+        freq = np.array([0, 1])
+        dirs = np.array([0, 90, 180])
         vals = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        grid_rot = grid.rotate(45, degrees=True)
+
+        freq_expect = (2.0 * np.pi) * np.array([0, 1])
+        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 315])
+        vals_expect = np.array(
+            [
+                [2, 3, 1],
+                [2, 3, 1],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
+        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
+        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
+
+    def test_rotate_deg_neg(self):
+        freq = np.array([0, 1])
+        dirs = np.array([0, 90, 180])
+        vals = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        grid_rot = grid.rotate(-45, degrees=True)
+
+        freq_expect = (2.0 * np.pi) * np.array([0, 1])
+        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 225])
+        vals_expect = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
+        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
+        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
+
+    def test_rotate_rad(self):
+        freq = np.array([0, 1])
+        dirs = np.array([0, 90, 180])
+        vals = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        grid_rot = grid.rotate(np.pi / 4, degrees=False)
+
+        freq_expect = (2.0 * np.pi) * np.array([0, 1])
+        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 315])
+        vals_expect = np.array(
+            [
+                [2, 3, 1],
+                [2, 3, 1],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
+        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
+        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
+
+    def test_rotate_rad_neg(self):
+        freq = np.array([0, 1])
+        dirs = np.array([0, 90, 180])
+        vals = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        grid_rot = grid.rotate(-np.pi / 4, degrees=False)
+
+        freq_expect = (2.0 * np.pi) * np.array([0, 1])
+        dirs_expect = (np.pi / 180.0) * np.array([45, 135, 225])
+        vals_expect = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(grid_rot._freq, freq_expect)
+        np.testing.assert_array_almost_equal(grid_rot._dirs, dirs_expect)
+        np.testing.assert_array_almost_equal(grid_rot._vals, vals_expect)
+
+    def test_grid(self):
+        freq = np.array([0, 1])
+        dirs = np.array([0, 90, 180])
+        vals = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        freq_out, dirs_out, vals_out = grid.grid(freq_hz=True, degrees=True)
+
+        freq_expect = np.array([0, 1])
+        dirs_expect = np.array([0, 90, 180])
+        vals_expect = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test__grid2(self):
+        freq = np.array([0, 1])
+        dirs = np.array([0, 90, 180])
+        vals = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+        grid = Grid(
+            freq,
+            dirs,
+            vals,
+            freq_hz=True,
+            degrees=True,
+            clockwise=False,
+            waves_coming_from=True,
+        )
+
+        freq_out, dirs_out, vals_out = grid.grid(freq_hz=False, degrees=False)
+
+        freq_expect = (2.0 * np.pi) * np.array([0, 1])
+        dirs_expect = (np.pi / 180.0) * np.array([0, 90, 180])
+        vals_expect = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test__mul__(self):
+        freq_in = np.array([1, 2, 3])
+        dirs_in = np.array([0, 10, 20, 30])
+        vals_in = np.array(
             [
                 [1, 2, 3, 4],
                 [1, 2, 3, 4],
                 [1, 2, 3, 4],
             ]
         )
-        grid = BinGrid(freq, dirs, vals, freq_hz=True, degrees=True)
+        grid = Grid(freq_in, dirs_in, vals_in, degrees=True)
 
-        # extrapolate
-        vals_out = grid.interpolate([10, 20], freq_hz=True)
-
-        vals_expect = np.zeros((2, len(dirs)))
-
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_interpolate_fill_value_None(self):
-        freq = np.array([0, 1, 2])
-        dirs = np.array([0, 90, 180, 270])
-        vals = np.array(
-            [
-                [1, 2, 3, 4],
-                [1, 2, 3, 4],
-                [1, 2, 3, 4],
-            ]
-        )
-        grid = BinGrid(freq, dirs, vals, freq_hz=True, degrees=True)
-
-        # extrapolate
-        vals_out = grid.interpolate([10, 20], freq_hz=True, fill_value=None)
+        grid_squared = grid * grid
 
         vals_expect = np.array(
             [
-                [1.0, 2.0, 3.0, 4.0],
-                [1.0, 2.0, 3.0, 4.0],
+                [1, 4, 9, 16],
+                [1, 4, 9, 16],
+                [1, 4, 9, 16],
             ]
         )
 
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+        assert isinstance(grid_squared, Grid)
+        assert grid_squared._clockwise == grid._clockwise
+        assert grid_squared._waves_coming_from == grid._waves_coming_from
+        np.testing.assert_array_almost_equal(grid_squared._freq, grid._freq)
+        np.testing.assert_array_almost_equal(grid_squared._dirs, grid._dirs)
+        np.testing.assert_array_almost_equal(grid_squared._vals, vals_expect)
 
-    def test_interpolate_complex_rectangular(self):
-        a_real = 7
-        b_real = 6
-        a_imag = 3
-        b_imag = 9
+    def test__mul__numeric(self, grid):
+        grid_scaled = grid * 2.0
+        np.testing.assert_array_almost_equal(grid_scaled._vals, grid._vals * 2.0)
 
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp_real = np.array([[a_real * x_i + b_real * y_i for x_i in xp] for y_i in yp])
-        vp_imag = np.array([[a_imag * x_i + b_imag * y_i for x_i in xp] for y_i in yp])
-        vp = vp_real + 1j * vp_imag
-        grid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
+        grid_scaled = grid * -2.0
+        np.testing.assert_array_almost_equal(grid_scaled._vals, grid._vals * -2.0)
 
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        vals_real_expect = np.array(
-            [[a_real * x_i + b_real * y_i for x_i in x] for y_i in y]
-        )
-        vals_imag_expect = np.array(
-            [[a_imag * x_i + b_imag * y_i for x_i in x] for y_i in y]
-        )
-        vals_expect = vals_real_expect + 1j * vals_imag_expect
+        grid_scaled = grid * 0.0
+        np.testing.assert_array_almost_equal(grid_scaled._vals, grid._vals * 0.0)
 
-        vals_out = grid.interpolate(y, freq_hz=True, complex_convert="rectangular")
+        grid_scaled = grid * 2
+        np.testing.assert_array_almost_equal(grid_scaled._vals, grid._vals * 2)
 
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_interpolate_complex_polar(self):
-        a_amp = 7
-        b_amp = 6
-        a_phase = 0.01
-        b_phase = 0.03
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp_amp = np.array([[a_amp * x_i + b_amp * y_i for x_i in xp] for y_i in yp])
-        vp_phase = np.array(
-            [[a_phase * x_i + b_phase * y_i for x_i in xp] for y_i in yp]
-        )
-        vp = vp_amp * (np.cos(vp_phase) + 1j * np.sin(vp_phase))
-        grid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.0, 2.0, 200)
-        x = xp
-        vals_amp_expect = np.array(
-            [[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y]
-        )
-        x_, y_ = np.meshgrid(x, y, indexing="ij", sparse=True)
-        vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
-        vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
-
-        vals_expect = (
-            vals_amp_expect
-            * (vals_phase_cos_expect + 1j * vals_phase_sin_expect)
-            / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        grid_scaled = grid * (1 + 1j)
+        np.testing.assert_array_almost_equal(
+            grid_scaled._vals, grid._vals * (1 + 1j)
         )
 
-        vals_out = grid.interpolate(y, freq_hz=True, complex_convert="polar")
+    def test__rmul__numeric(self, grid):
+        grid_scaled = 2.0 * grid
+        np.testing.assert_array_almost_equal(grid_scaled._vals, grid._vals * 2.0)
 
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+    def test__mul__raises_array(self, grid):
+        with pytest.raises(TypeError):
+            grid * grid._vals
 
-    def test_interpolate_raises_freq(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = BinGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
+    def test__mul__raises_type(self, grid, rao):
+        with pytest.raises(TypeError):
+            grid * rao
+
+    def test__mul__raises_shape(self):
+        freq_in = np.array([1, 2, 3])
+        dirs_in = np.array([0, 10, 20, 30])
+        vals_in = np.array(
+            [
+                [1, 2, 3, 4],
+                [1, 2, 3, 4],
+                [1, 2, 3, 4],
+            ]
+        )
+        grid = Grid(freq_in, dirs_in, vals_in, degrees=True)
+
+        freq_in2 = np.array([1, 2])
+        dirs_in2 = np.array([0, 10, 20])
+        vals_in2 = np.array(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        )
+        grid2 = Grid(freq_in2, dirs_in2, vals_in2, degrees=True)
+
+        with pytest.raises(ValueError):
+            grid * grid2
+
+    def test__mul__raises_freq(self, grid):
+        grid2 = grid.copy()
+        grid2._freq = 2.0 * grid2._freq
+
+        with pytest.raises(ValueError):
+            grid * grid2
+
+    def test__mul__raises_dirs(self, grid):
+        grid2 = grid.copy()
+        grid2._dirs = 2.0 * grid2._dirs
+
+        with pytest.raises(ValueError):
+            grid * grid2
+
+    def test__mul__raises_convention(self, grid):
+        grid.set_wave_convention(clockwise=False, waves_coming_from=False)
+
+        grid2 = grid.copy()
+        grid2.set_wave_convention(clockwise=True, waves_coming_from=False)
+        with pytest.raises(ValueError):
+            grid * grid2
+
+        grid3 = grid.copy()
+        grid3.set_wave_convention(clockwise=False, waves_coming_from=True)
+        with pytest.raises(ValueError):
+            grid * grid3
+
+    def test__add__(self, grid):
+        out = grid + grid
+
+        assert isinstance(out, Grid)
+        np.testing.assert_array_almost_equal(
+            out._vals, grid._vals + grid._vals
+        )
+
+    def test__add__raises_type(self, grid, rao):
+        with pytest.raises(TypeError):
+            grid + rao
+
+    @patch("waveresponse._core._check_is_similar")
+    def test__add__check_is_similar(self, mock_check_is_similar, grid):
+        grid + grid
+        mock_check_is_similar.assert_called_once_with(
+            grid, grid, exact_type=True
+        )
+
+    def test__add__numeric(self, grid):
+        grid_added = grid + 2.0
+        np.testing.assert_array_almost_equal(grid_added._vals, grid._vals + 2.0)
+
+        grid_added = grid + 0.0
+        np.testing.assert_array_almost_equal(grid_added._vals, grid._vals + 0.0)
+
+        grid_added = grid + 2
+        np.testing.assert_array_almost_equal(grid_added._vals, grid._vals + 2)
+
+        grid_added = grid + (1 + 1j)
+        np.testing.assert_array_almost_equal(
+            grid_added._vals, grid._vals + (1 + 1j)
+        )
+
+    def test__radd__numeric(self, grid):
+        grid_added = 2.0 + grid
+        np.testing.assert_array_almost_equal(grid_added._vals, grid._vals + 2.0)
+
+    def test__sub__(self, grid):
+        out = grid - grid
+
+        assert isinstance(out, Grid)
+        np.testing.assert_array_almost_equal(
+            out._vals, grid._vals - grid._vals
+        )
+
+    @patch("waveresponse._core._check_is_similar")
+    def test__sub__check_is_similar(self, mock_check_is_similar, grid):
+        grid - grid
+        mock_check_is_similar.assert_called_once_with(
+            grid, grid, exact_type=True
+        )
+
+    def test__sub__raises_type(self, grid, rao):
+        with pytest.raises(TypeError):
+            grid - rao
+
+    def test__sub__numeric(self, grid):
+        grid_subtracted = grid - 2.0
+        np.testing.assert_array_almost_equal(
+            grid_subtracted._vals, grid._vals - 2.0
+        )
+
+        grid_subtracted = grid - 0.0
+        np.testing.assert_array_almost_equal(
+            grid_subtracted._vals, grid._vals - 0.0
+        )
+
+        grid_subtracted = grid - 2
+        np.testing.assert_array_almost_equal(grid_subtracted._vals, grid._vals - 2)
+
+        grid_subtracted = grid - (1 + 1j)
+        np.testing.assert_array_almost_equal(
+            grid_subtracted._vals, grid._vals - (1 + 1j)
+        )
+
+    def test__rsub__numeric(self, grid):
+        grid_subtracted = 2.0 - grid
+        np.testing.assert_array_almost_equal(
+            grid_subtracted._vals, grid._vals - 2.0
+        )
+
+    def test_conjugate(self, grid):
+        grid_conj = grid.conjugate()
+
+        np.testing.assert_array_almost_equal(grid_conj._freq, grid._freq)
+        np.testing.assert_array_almost_equal(grid_conj._dirs, grid._dirs)
+        np.testing.assert_array_almost_equal(
+            grid_conj._vals, grid._vals.conjugate()
+        )
+
+    def test_real(self):
+        freq_in = np.array([1, 2, 3])
+        dirs_in = np.array([0, 10, 20])
+        vals_in = np.array(
+            [
+                [1.0 + 0.0j, 0.0 + 1.0j, -1.0 + 0.0j],
+                [2.0 + 0.0j, 0.0 - 2.0j, -2.0 + 0.0j],
+                [3.0 + 0.0j, 0.0 + 3.0j, -3.0 + 0.0j],
+            ]
+        )
+        grid = Grid(
+            freq_in,
+            dirs_in,
+            vals_in,
             degrees=True,
             clockwise=True,
             waves_coming_from=True,
         )
 
-        with pytest.raises(ValueError):
-            grid.interpolate([0, 1, 2, 1])  # freq not monotonically increasing
+        grid_real = grid.real
 
-    def test_reshape(self):
-        a = 7
-        b = 6
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
-        bingrid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        grid_reshaped = bingrid.reshape(y, freq_hz=True)
-
-        freq_expect = (2.0 * np.pi) * y
-        dirs_expect = (np.pi / 180.0) * x
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        freq_out = grid_reshaped._freq
-        dirs_out = grid_reshaped._dirs
-        vals_out = grid_reshaped._vals
-
-        np.testing.assert_array_almost_equal(freq_out, freq_expect)
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_reshape2(self):
-        a = 7
-        b = 6
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
-        grid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        y_ = (2.0 * np.pi) * y
-        grid_reshaped = grid.reshape(y_, freq_hz=False)
-
-        freq_expect = (2.0 * np.pi) * y
-        dirs_expect = (np.pi / 180.0) * x
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        freq_out = grid_reshaped._freq
-        dirs_out = grid_reshaped._dirs
-        vals_out = grid_reshaped._vals
-
-        np.testing.assert_array_almost_equal(freq_out, freq_expect)
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_reshape_complex_rectangular(self):
-        a_real = 7
-        b_real = 6
-        a_imag = 3
-        b_imag = 9
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp_real = np.array([[a_real * x_i + b_real * y_i for x_i in xp] for y_i in yp])
-        vp_imag = np.array([[a_imag * x_i + b_imag * y_i for x_i in xp] for y_i in yp])
-        vp = vp_real + 1j * vp_imag
-        bingrid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        grid_reshaped = bingrid.reshape(y, freq_hz=True, complex_convert="rectangular")
-
-        freq_out = grid_reshaped._freq
-        dirs_out = grid_reshaped._dirs
-        vals_out = grid_reshaped._vals
-
-        freq_expect = (2.0 * np.pi) * y
-        dirs_expect = (np.pi / 180.0) * x
-        vals_real_expect = np.array(
-            [[a_real * x_i + b_real * y_i for x_i in x] for y_i in y]
-        )
-        vals_imag_expect = np.array(
-            [[a_imag * x_i + b_imag * y_i for x_i in x] for y_i in y]
-        )
-        vals_expect = vals_real_expect + 1j * vals_imag_expect
-
-        np.testing.assert_array_almost_equal(freq_out, freq_expect)
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_reshape_complex_polar(self):
-        a_amp = 7
-        b_amp = 6
-        a_phase = 0.01
-        b_phase = 0.03
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp_amp = np.array([[a_amp * x_i + b_amp * y_i for x_i in xp] for y_i in yp])
-        vp_phase = np.array(
-            [[a_phase * x_i + b_phase * y_i for x_i in xp] for y_i in yp]
-        )
-        vp = vp_amp * (np.cos(vp_phase) + 1j * np.sin(vp_phase))
-        bingrid = BinGrid(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        grid_reshaped = bingrid.reshape(y, freq_hz=True, complex_convert="polar")
-
-        freq_out = grid_reshaped._freq
-        dirs_out = grid_reshaped._dirs
-        vals_out = grid_reshaped._vals
-
-        freq_expect = (2.0 * np.pi) * y
-        dirs_expect = (np.pi / 180.0) * x
-        vals_amp_expect = np.array(
-            [[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y]
-        )
-        x_, y_ = np.meshgrid(x, y, indexing="ij", sparse=True)
-        vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
-        vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
-
-        vals_expect = (
-            vals_amp_expect
-            * (vals_phase_cos_expect + 1j * vals_phase_sin_expect)
-            / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        vals_expect = np.array(
+            [
+                [1.0, 0.0, -1.0],
+                [2.0, 0.0, -2.0],
+                [3.0, 0.0, -3.0],
+            ]
         )
 
-        np.testing.assert_array_almost_equal(freq_out, freq_expect)
-        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+        assert isinstance(grid_real, Grid)
+        np.testing.assert_array_almost_equal(grid_real._vals, vals_expect)
 
-    def test_reshape_raises_freq(self):
-        freq = np.linspace(0, 1.0, 10)
-        dirs = np.linspace(0, 360.0, 15, endpoint=False)
-        vals = np.zeros((10, 15))
-        grid = BinGrid(
-            freq,
-            dirs,
-            vals,
-            freq_hz=True,
+    def test_imag(self):
+        freq_in = np.array([1, 2, 3])
+        dirs_in = np.array([0, 10, 20])
+        vals_in = np.array(
+            [
+                [1.0 + 0.0j, 0.0 + 1.0j, -1.0 + 0.0j],
+                [2.0 + 0.0j, 0.0 - 2.0j, -2.0 + 0.0j],
+                [3.0 + 0.0j, 0.0 + 3.0j, -3.0 + 0.0j],
+            ]
+        )
+        grid = Grid(
+            freq_in,
+            dirs_in,
+            vals_in,
             degrees=True,
             clockwise=True,
             waves_coming_from=True,
         )
 
-        with pytest.raises(ValueError):
-            grid.reshape([0, 1, 2, 1])  # freq not monotonically increasing
+        grid_imag = grid.imag
 
-    def test__repr__(self, bingrid):
-        assert str(bingrid) == "BinGrid"
+        vals_expect = np.array(
+            [
+                [0.0, 1.0, 0.0],
+                [0.0, -2.0, 0.0],
+                [0.0, 3.0, 0.0],
+            ]
+        )
+
+        assert isinstance(grid_imag, Grid)
+        np.testing.assert_array_almost_equal(grid_imag._vals, vals_expect)
 
 
 class Test_RAO:
@@ -4086,7 +3711,7 @@ class Test_DirectionalBinSpectrum:
             waves_coming_from=True,
         )
 
-        assert isinstance(spectrum, BinGrid)
+        assert isinstance(spectrum, Grid)
         assert spectrum._clockwise is True
         assert spectrum._waves_coming_from is True
         np.testing.assert_array_almost_equal(spectrum._freq, 2.0 * np.pi * freq_in)
@@ -4109,7 +3734,7 @@ class Test_DirectionalBinSpectrum:
             waves_coming_from=True,
         )
 
-        assert isinstance(spectrum, BinGrid)
+        assert isinstance(spectrum, Grid)
         assert spectrum._clockwise is False
         assert spectrum._waves_coming_from is True
         np.testing.assert_array_almost_equal(spectrum._freq, 2.0 * np.pi * freq_in)
@@ -4132,7 +3757,7 @@ class Test_DirectionalBinSpectrum:
             waves_coming_from=False,
         )
 
-        assert isinstance(spectrum, BinGrid)
+        assert isinstance(spectrum, Grid)
         assert spectrum._clockwise is True
         assert spectrum._waves_coming_from is False
         np.testing.assert_array_almost_equal(spectrum._freq, freq_in)
@@ -4153,7 +3778,7 @@ class Test_DirectionalBinSpectrum:
             waves_coming_from=False,
         )
 
-        assert isinstance(spectrum, BinGrid)
+        assert isinstance(spectrum, Grid)
         assert spectrum._clockwise is False
         assert spectrum._waves_coming_from is False
         np.testing.assert_array_almost_equal(spectrum._freq, freq_in)
@@ -4323,7 +3948,7 @@ class Test_DirectionalBinSpectrum:
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
-    def test_interpolate_hz_deg(self):
+    def test_interpolate(self):
         a = 7
         b = 6
 
@@ -4336,55 +3961,8 @@ class Test_DirectionalBinSpectrum:
         x = xp
         vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
 
-        vals_out = spectrum.interpolate(y, freq_hz=True)
-
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_interpolate_hz_rad(self):
-        a = 7
-        b = 6
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
-        spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        x *= np.pi / 180.0
-
-        vals_out = spectrum.interpolate(y, freq_hz=True)
-
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    def test_interpolate_rads_rad(self):
-        a = 7
-        b = 6
-
-        yp = np.linspace(0.0, 2.0, 20)
-        xp = np.linspace(0.0, 359.0, 10)
-        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
-        spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
-
-        y = np.linspace(0.5, 1.0, 20)
-        x = xp
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
-
-        x *= np.pi / 180.0
-        y *= 2.0 * np.pi
-        vals_expect /= 2.0 * np.pi
-
-        vals_out = spectrum.interpolate(y, freq_hz=False)
-
-        np.testing.assert_array_almost_equal(vals_out, vals_expect)
-
-    testdata_full_range_dir = [
-        ([1.0, 2.0, 3.0], [0.0, 1.0, 2.0, 3.0, 2.0 * np.pi]),
-        ([0.0, 1.0, 2.0, 3.0], [0.0, 1.0, 2.0, 3.0, 2.0 * np.pi]),
-        ([0.0, 1.0, 2.0, 3.0, 2.0 * np.pi], [0.0, 1.0, 2.0, 3.0, 2.0 * np.pi]),
-    ]
+        with pytest.raises(NotImplementedError):
+            _ = spectrum.interpolate(y, freq_hz=True)
 
     def test_var(self):
         y0 = 0.0


### PR DESCRIPTION
### This PR is related to user story

## Description
BinGrid is deprecated as it appeared superfluous.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
