### PR TITLE
Fix dirm degrees default and wrong scaling when .reshape is called

### DIFF
--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -1818,12 +1818,6 @@ class DirectionalSpectrum(_SpectrumMixin, Grid):
 
         vals_new = interp_fun(freq_new, dirs_new)
 
-        if freq_hz:
-            vals_new *= 2.0 * np.pi
-
-        if degrees:
-            vals_new *= np.pi / 180.0
-
         new = self.copy()
         new._freq, new._dirs, new._vals = freq_new, dirs_new, vals_new
         return new
@@ -2002,9 +1996,6 @@ class DirectionalBinSpectrum(_SpectrumMixin, Grid):
         )
 
         vals_new = interp_fun(freq_new, self._dirs)
-
-        if freq_hz:
-            vals_new *= 2.0 * np.pi
 
         new = self.copy()
         new._freq, new._vals = freq_new, vals_new

--- a/src/waveresponse/_core.py
+++ b/src/waveresponse/_core.py
@@ -2140,6 +2140,9 @@ class WaveSpectrum(DisableComplexMixin, DirectionalSpectrum):
             during instantiation.
         """
 
+        if degrees is None:
+            degrees = self._degrees
+
         dp, sp = self.spectrum1d(axis=0, degrees=False)
 
         d = self._full_range_dir(dp)
@@ -2287,6 +2290,9 @@ class WaveBinSpectrum(DisableComplexMixin, DirectionalBinSpectrum):
             the direction is returned in 'radians'. Defaults to original unit used
             during instantiation.
         """
+
+        if degrees is None:
+            degrees = self._degrees
 
         dirm = self._mean_direction(*self.spectrum1d(axis=0, degrees=False))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5089,6 +5089,135 @@ class Test_DirectionalBinSpectrum:
         assert extreme_out == pytest.approx(extreme_expect)
 
 
+    def test_reshape(self):
+        a = 7
+        b = 6
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
+        spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        grid_reshaped = spectrum.reshape(y, freq_hz=True)
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * xp
+        vals_expect = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in y]) / (2.0 * np.pi)
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_reshape2(self):
+        a = 7
+        b = 6
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
+        spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        y_ = (2.0 * np.pi) * y
+        grid_reshaped = spectrum.reshape(y_, freq_hz=False)
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * xp
+        vals_expect = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in y]) / (2.0 * np.pi)
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_reshape_complex_rectangular(self):
+        a_real = 7
+        b_real = 6
+        a_imag = 3
+        b_imag = 9
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp_real = np.array([[a_real * x_i + b_real * y_i for x_i in xp] for y_i in yp])
+        vp_imag = np.array([[a_imag * x_i + b_imag * y_i for x_i in xp] for y_i in yp])
+        vp = vp_real + 1j * vp_imag
+        spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        grid_reshaped = spectrum.reshape(
+            y, freq_hz=True, complex_convert="rectangular"
+        )
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * xp
+        vals_real_expect = np.array(
+            [[a_real * x_i + b_real * y_i for x_i in xp] for y_i in y]
+        )
+        vals_imag_expect = np.array(
+            [[a_imag * x_i + b_imag * y_i for x_i in xp] for y_i in y]
+        )
+        vals_expect = (vals_real_expect + 1j * vals_imag_expect) / (2.0 * np.pi)
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_reshape_complex_polar(self):
+        a_amp = 7
+        b_amp = 6
+        a_phase = 0.01
+        b_phase = 0.03
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp_amp = np.array([[a_amp * x_i + b_amp * y_i for x_i in xp] for y_i in yp])
+        vp_phase = np.array(
+            [[a_phase * x_i + b_phase * y_i for x_i in xp] for y_i in yp]
+        )
+        vp = vp_amp * (np.cos(vp_phase) + 1j * np.sin(vp_phase))
+        spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        grid_reshaped = spectrum.reshape(
+            y, freq_hz=True, complex_convert="polar"
+        )
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * xp
+        vals_amp_expect = np.array(
+            [[a_amp * x_i + b_amp * y_i for x_i in xp] for y_i in y]
+        ) / (2.0 * np.pi)
+        x_, y_ = np.meshgrid(xp, y, indexing="ij", sparse=True)
+        vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
+        vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
+
+        vals_expect = (
+            vals_amp_expect
+            * (vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+            / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        )
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+
 class Test_WaveSpectrum:
     def test__init__(self):
         freq = np.linspace(0, 1.0, 10)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4171,7 +4171,11 @@ class Test_DirectionalSpectrum:
 
         freq_expect = (2.0 * np.pi) * y
         dirs_expect = (np.pi / 180.0) * x
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y]) * (180.0 / np.pi) / (2.0 * np.pi)
+        vals_expect = (
+            np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
+            * (180.0 / np.pi)
+            / (2.0 * np.pi)
+        )
 
         freq_out = grid_reshaped._freq
         dirs_out = grid_reshaped._dirs
@@ -4198,7 +4202,11 @@ class Test_DirectionalSpectrum:
 
         freq_expect = (2.0 * np.pi) * y
         dirs_expect = (np.pi / 180.0) * x
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y]) * (180.0 / np.pi) / (2.0 * np.pi)
+        vals_expect = (
+            np.array([[a * x_i + b * y_i for x_i in x] for y_i in y])
+            * (180.0 / np.pi)
+            / (2.0 * np.pi)
+        )
 
         freq_out = grid_reshaped._freq
         dirs_out = grid_reshaped._dirs
@@ -4239,7 +4247,9 @@ class Test_DirectionalSpectrum:
         vals_imag_expect = np.array(
             [[a_imag * x_i + b_imag * y_i for x_i in x] for y_i in y]
         )
-        vals_expect = (vals_real_expect + 1j * vals_imag_expect) * (180.0 / np.pi) / (2.0 * np.pi)
+        vals_expect = (
+            (vals_real_expect + 1j * vals_imag_expect) * (180.0 / np.pi) / (2.0 * np.pi)
+        )
 
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
@@ -4272,9 +4282,11 @@ class Test_DirectionalSpectrum:
 
         freq_expect = (2.0 * np.pi) * y
         dirs_expect = (np.pi / 180.0) * x
-        vals_amp_expect = np.array(
-            [[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y]
-        ) * (180.0 / np.pi) / (2.0 * np.pi)
+        vals_amp_expect = (
+            np.array([[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y])
+            * (180.0 / np.pi)
+            / (2.0 * np.pi)
+        )
         x_, y_ = np.meshgrid(x, y, indexing="ij", sparse=True)
         vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
         vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
@@ -4288,6 +4300,7 @@ class Test_DirectionalSpectrum:
         np.testing.assert_array_almost_equal(freq_out, freq_expect)
         np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
         np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
 
 class Test_DirectionalBinSpectrum:
     def test__init___hz_deg(self):
@@ -5088,7 +5101,6 @@ class Test_DirectionalBinSpectrum:
 
         assert extreme_out == pytest.approx(extreme_expect)
 
-
     def test_reshape(self):
         a = 7
         b = 6
@@ -5103,7 +5115,9 @@ class Test_DirectionalBinSpectrum:
 
         freq_expect = (2.0 * np.pi) * y
         dirs_expect = (np.pi / 180.0) * xp
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in y]) / (2.0 * np.pi)
+        vals_expect = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in y]) / (
+            2.0 * np.pi
+        )
 
         freq_out = grid_reshaped._freq
         dirs_out = grid_reshaped._dirs
@@ -5128,7 +5142,9 @@ class Test_DirectionalBinSpectrum:
 
         freq_expect = (2.0 * np.pi) * y
         dirs_expect = (np.pi / 180.0) * xp
-        vals_expect = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in y]) / (2.0 * np.pi)
+        vals_expect = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in y]) / (
+            2.0 * np.pi
+        )
 
         freq_out = grid_reshaped._freq
         dirs_out = grid_reshaped._dirs
@@ -5152,9 +5168,7 @@ class Test_DirectionalBinSpectrum:
         spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
 
         y = np.linspace(0.5, 1.0, 20)
-        grid_reshaped = spectrum.reshape(
-            y, freq_hz=True, complex_convert="rectangular"
-        )
+        grid_reshaped = spectrum.reshape(y, freq_hz=True, complex_convert="rectangular")
 
         freq_out = grid_reshaped._freq
         dirs_out = grid_reshaped._dirs
@@ -5190,9 +5204,7 @@ class Test_DirectionalBinSpectrum:
         spectrum = DirectionalBinSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
 
         y = np.linspace(0.5, 1.0, 20)
-        grid_reshaped = spectrum.reshape(
-            y, freq_hz=True, complex_convert="polar"
-        )
+        grid_reshaped = spectrum.reshape(y, freq_hz=True, complex_convert="polar")
 
         freq_out = grid_reshaped._freq
         dirs_out = grid_reshaped._dirs

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4156,6 +4156,138 @@ class Test_DirectionalSpectrum:
 
         assert extreme_out == pytest.approx(extreme_expect)
 
+    def test_reshape(self):
+        a = 7
+        b = 6
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        x = np.linspace(5.0, 15.0, 10)
+        grid_reshaped = spectrum.reshape(y, x, freq_hz=True, degrees=True)
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * x
+        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y]) * (180.0 / np.pi) / (2.0 * np.pi)
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_reshape2(self):
+        a = 7
+        b = 6
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp = np.array([[a * x_i + b * y_i for x_i in xp] for y_i in yp])
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        x = np.linspace(5.0, 15.0, 10)
+        y_ = (2.0 * np.pi) * y
+        x_ = (np.pi / 180.0) * x
+        grid_reshaped = spectrum.reshape(y_, x_, freq_hz=False, degrees=False)
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * x
+        vals_expect = np.array([[a * x_i + b * y_i for x_i in x] for y_i in y]) * (180.0 / np.pi) / (2.0 * np.pi)
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_reshape_complex_rectangular(self):
+        a_real = 7
+        b_real = 6
+        a_imag = 3
+        b_imag = 9
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp_real = np.array([[a_real * x_i + b_real * y_i for x_i in xp] for y_i in yp])
+        vp_imag = np.array([[a_imag * x_i + b_imag * y_i for x_i in xp] for y_i in yp])
+        vp = vp_real + 1j * vp_imag
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        x = np.linspace(5.0, 15.0, 10)
+        grid_reshaped = spectrum.reshape(
+            y, x, freq_hz=True, degrees=True, complex_convert="rectangular"
+        )
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * x
+        vals_real_expect = np.array(
+            [[a_real * x_i + b_real * y_i for x_i in x] for y_i in y]
+        )
+        vals_imag_expect = np.array(
+            [[a_imag * x_i + b_imag * y_i for x_i in x] for y_i in y]
+        )
+        vals_expect = (vals_real_expect + 1j * vals_imag_expect) * (180.0 / np.pi) / (2.0 * np.pi)
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
+
+    def test_reshape_complex_polar(self):
+        a_amp = 7
+        b_amp = 6
+        a_phase = 0.01
+        b_phase = 0.03
+
+        yp = np.linspace(0.0, 2.0, 20)
+        xp = np.linspace(0.0, 359.0, 10)
+        vp_amp = np.array([[a_amp * x_i + b_amp * y_i for x_i in xp] for y_i in yp])
+        vp_phase = np.array(
+            [[a_phase * x_i + b_phase * y_i for x_i in xp] for y_i in yp]
+        )
+        vp = vp_amp * (np.cos(vp_phase) + 1j * np.sin(vp_phase))
+        spectrum = DirectionalSpectrum(yp, xp, vp, freq_hz=True, degrees=True)
+
+        y = np.linspace(0.5, 1.0, 20)
+        x = np.linspace(5.0, 15.0, 10)
+        grid_reshaped = spectrum.reshape(
+            y, x, freq_hz=True, degrees=True, complex_convert="polar"
+        )
+
+        freq_out = grid_reshaped._freq
+        dirs_out = grid_reshaped._dirs
+        vals_out = grid_reshaped._vals
+
+        freq_expect = (2.0 * np.pi) * y
+        dirs_expect = (np.pi / 180.0) * x
+        vals_amp_expect = np.array(
+            [[a_amp * x_i + b_amp * y_i for x_i in x] for y_i in y]
+        ) * (180.0 / np.pi) / (2.0 * np.pi)
+        x_, y_ = np.meshgrid(x, y, indexing="ij", sparse=True)
+        vals_phase_cos_expect = RGI((xp, yp), np.cos(vp_phase).T)((x_, y_)).T
+        vals_phase_sin_expect = RGI((xp, yp), np.sin(vp_phase).T)((x_, y_)).T
+
+        vals_expect = (
+            vals_amp_expect
+            * (vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+            / np.abs(vals_phase_cos_expect + 1j * vals_phase_sin_expect)
+        )
+
+        np.testing.assert_array_almost_equal(freq_out, freq_expect)
+        np.testing.assert_array_almost_equal(dirs_out, dirs_expect)
+        np.testing.assert_array_almost_equal(vals_out, vals_expect)
 
 class Test_DirectionalBinSpectrum:
     def test__init___hz_deg(self):


### PR DESCRIPTION
### This PR is related to user story [ESS-XXXX](url_to_jira_task)

## Description
Performed unnecessary and wrong scaling to internal representation of values when .reshape is called.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
